### PR TITLE
fix: throw error when  profile id is undefined and providers flag is …

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ _See code: [src/commands/create.ts](https://github.com/superfaceai/cli/tree/main
 
 ## `superface install [PROFILEID]`
 
-Initializes superface directory if needed, communicates with Superface Store API, stores profiles and compiled files to a local system
+Initializes superface directory if needed, communicates with Superface Store API, stores profiles and compiled files to a local system. Install without any arguments tries to install profiles and providers listed in super.json
 
 ```
 USAGE
@@ -173,8 +173,8 @@ OPTIONS
 
 EXAMPLES
   $ superface install
-  $ superface install --provider twilio
   $ superface install sms/service@1.0
+  $ superface install sms/service@1.0 --providers twilio
   $ superface install sms/service@1.0 -p twilio
   $ superface install --local sms/service.supr
 ```

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -115,6 +115,27 @@ describe('Install CLI command', () => {
       );
     }, 10000);
 
+    it('calls install profiles correctly without profileId', async () => {
+      mocked(detectSuperJson).mockResolvedValue('.');
+
+      await expect(Install.run([])).resolves.toBeUndefined();
+      expect(installProfiles).toHaveBeenCalledTimes(1);
+      expect(installProfiles).toHaveBeenCalledWith('.', [], {
+        logCb: expect.any(Function),
+        warnCb: expect.any(Function),
+        force: false,
+      });
+    }, 10000);
+
+    it('throws error on empty profileId argument with providers flag', async () => {
+      mocked(detectSuperJson).mockResolvedValue('.');
+
+      await expect(Install.run(['--providers', 'twilio'])).rejects.toEqual(
+        new CLIError('EEXIT: 0')
+      );
+      expect(installProfiles).not.toHaveBeenCalled();
+    }, 10000);
+
     it('throws error on empty providers flag', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
       const profileName = 'starwars/character-information';

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -41,7 +41,7 @@ const parseProviders = (
 
 export default class Install extends Command {
   static description =
-    'Initializes superface directory if needed, communicates with Superface Store API, stores profiles and compiled files to a local system';
+    'Initializes superface directory if needed, communicates with Superface Store API, stores profiles and compiled files to a local system. Install without any arguments tries to install profiles and providers listed in super.json';
 
   static args = [
     {
@@ -49,6 +49,7 @@ export default class Install extends Command {
       required: false,
       description:
         'Profile identifier consisting of scope (optional), profile name and its version.',
+      default: undefined,
     },
   ];
 
@@ -82,8 +83,8 @@ export default class Install extends Command {
 
   static examples = [
     '$ superface install',
-    '$ superface install --provider twilio',
     '$ superface install sms/service@1.0',
+    '$ superface install sms/service@1.0 --providers twilio',
     '$ superface install sms/service@1.0 -p twilio',
     '$ superface install --local sms/service.supr',
   ];
@@ -158,6 +159,14 @@ export default class Install extends Command {
           profileId,
           version,
         });
+      }
+    } else {
+      //Do not install providers without profile
+      if (providers.length > 0) {
+        this.warnCallback?.(
+          'Unable to install providers without profile. Please, specify profile'
+        );
+        this.exit();
       }
     }
 


### PR DESCRIPTION
…specified

<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR removes ability to use install command to install provider without profileId. Install without any argument/flag still works (install profiles/providers listed in super.json)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
