### PR TITLE
fix: incomplete configure command example

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ EXAMPLES
   $ superface configure twilio -p send-sms
   $ superface configure twilio -p send-sms -q
   $ superface configure twilio -p send-sms -f
-  $ superface configure twilio -p send-sms -l
+  $ superface configure providers/twilio.provider.json -p send-sms -l
 ```
 
 _See code: [src/commands/configure.ts](https://github.com/superfaceai/cli/tree/main/src/commands/configure.ts)_

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -49,7 +49,7 @@ export default class Configure extends Command {
     '$ superface configure twilio -p send-sms',
     '$ superface configure twilio -p send-sms -q',
     '$ superface configure twilio -p send-sms -f',
-    '$ superface configure twilio -p send-sms -l',
+    '$ superface configure providers/twilio.provider.json -p send-sms -l',
   ];
 
   private warnCallback? = (message: string) => this.log(yellow(message));


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

This PR fixes missing `-p <profileId>` in configure command example

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
