### PR TITLE
feat: remove .npmrc generation

### DIFF
--- a/src/commands/init.integration.test.ts
+++ b/src/commands/init.integration.test.ts
@@ -33,17 +33,12 @@ describe('Init CLI command', () => {
   it('initializes base folder', async () => {
     await expect(Init.run([testInitFolderPath])).resolves.toBeUndefined();
 
-    const expectedFiles = [
-      '.npmrc',
-      joinPath(SUPERFACE_DIR, '.gitignore'),
-      SUPER_PATH,
-    ];
+    const expectedFiles = [joinPath(SUPERFACE_DIR, '.gitignore'), SUPER_PATH];
 
     const expectedDirectories = [SUPERFACE_DIR, BUILD_DIR, TYPES_DIR, GRID_DIR];
 
     expect(stdout.output).toContain(
       `$ echo '<README.md template>' > 'fixtures/playgrounds/test/README.md'
-$ echo '<.npmrc template>' > 'fixtures/playgrounds/test/.npmrc'
 $ mkdir 'fixtures/playgrounds/test/superface'
 $ echo '<initial super.json>' > 'fixtures/playgrounds/test/superface/super.json'
 $ echo '<.gitignore template>' > 'fixtures/playgrounds/test/superface/.gitignore'
@@ -71,11 +66,7 @@ $ mkdir 'fixtures/playgrounds/test/superface/build'
   it('initializes base folder with quiet mode', async () => {
     await expect(Init.run([testInitFolderPath, '-q'])).resolves.toBeUndefined();
 
-    const expectedFiles = [
-      '.npmrc',
-      joinPath(SUPERFACE_DIR, '.gitignore'),
-      SUPER_PATH,
-    ];
+    const expectedFiles = [joinPath(SUPERFACE_DIR, '.gitignore'), SUPER_PATH];
 
     const expectedDirectories = [SUPERFACE_DIR, BUILD_DIR, TYPES_DIR, GRID_DIR];
 

--- a/src/commands/play.integration.test.ts
+++ b/src/commands/play.integration.test.ts
@@ -92,9 +92,6 @@ describe('Play CLI command', () => {
     ).resolves.toBeDefined();
 
     expect(stdout.output).toContain(
-      `$ echo '<.npmrc template>' > '${createdPlayground.path}/.npmrc'`
-    );
-    expect(stdout.output).toContain(
       `$ echo '<initial super.json>' > '${expectedFiles[3]}'`
     );
     expect(stdout.output).toContain(

--- a/src/common/document.ts
+++ b/src/common/document.ts
@@ -42,7 +42,6 @@ export const EXTENSIONS = {
 
 export const SUPERFACE_DIR = 'superface';
 export const META_FILE = 'super.json';
-export const NPMRC = '.npmrc';
 export const SUPER_PATH = joinPath(SUPERFACE_DIR, META_FILE);
 export const GRID_DIR = joinPath(SUPERFACE_DIR, 'grid');
 export const TYPES_DIR = joinPath(SUPERFACE_DIR, 'types');

--- a/src/logic/init.test.ts
+++ b/src/logic/init.test.ts
@@ -56,7 +56,7 @@ describe('Init logic', () => {
       expect(mkdirQuiet).toHaveBeenNthCalledWith(3, 'test/superface/types');
       expect(mkdirQuiet).toHaveBeenNthCalledWith(4, 'test/superface/build');
 
-      expect(writeIfAbsentSpy).toHaveBeenCalledTimes(4);
+      expect(writeIfAbsentSpy).toHaveBeenCalledTimes(3);
       expect(writeIfAbsentSpy).toHaveBeenNthCalledWith(
         1,
         'test/README.md',
@@ -65,18 +65,12 @@ describe('Init logic', () => {
       );
       expect(writeIfAbsentSpy).toHaveBeenNthCalledWith(
         2,
-        'test/.npmrc',
-        initTemplate.npmRc,
-        { force: undefined }
-      );
-      expect(writeIfAbsentSpy).toHaveBeenNthCalledWith(
-        3,
         'test/superface/super.json',
         expect.anything(),
         { force: undefined }
       );
       expect(writeIfAbsentSpy).toHaveBeenNthCalledWith(
-        4,
+        3,
         'test/superface/.gitignore',
         initTemplate.gitignore,
         { force: undefined }

--- a/src/logic/init.ts
+++ b/src/logic/init.ts
@@ -7,7 +7,6 @@ import {
   composeUsecaseName,
   GRID_DIR,
   META_FILE,
-  NPMRC,
   SUPERFACE_DIR,
   TYPES_DIR,
 } from '../common/document';
@@ -25,7 +24,6 @@ import { createProfile } from './create';
  * Inside the path the following structure is generated:
  * ```
  * appPath/
- *   .npmrc
  *   superface/
  *     super.json
  *     .gitignore
@@ -65,23 +63,6 @@ export async function initSuperface(
     if (created) {
       options?.logCb?.(
         formatShellLog("echo '<README.md template>' >", [readmePath])
-      );
-    }
-  }
-
-  // TODO: This will not be needed once we migrate
-  // to npm repository (since it is the default)
-  {
-    const npmrcPath = joinPath(appPath, NPMRC);
-    const created = await OutputStream.writeIfAbsent(
-      npmrcPath,
-      initTemplate.npmRc,
-      { force: options?.force }
-    );
-
-    if (created) {
-      options?.logCb?.(
-        formatShellLog("echo '<.npmrc template>' >", [npmrcPath])
       );
     }
   }

--- a/src/logic/playground.ts
+++ b/src/logic/playground.ts
@@ -327,7 +327,6 @@ export async function detectPlayground(
  *   name.supr
  *   name.provider.suma
  *   provider.provider.json
- *   .npmrc
  *   superface/
  *     super.json
  *     .gitignore

--- a/src/templates/init.ts
+++ b/src/templates/init.ts
@@ -1,7 +1,3 @@
-export function npmRc(): string {
-  return '@superfaceai:registry=https://npm.pkg.github.com\n';
-}
-
 export function gitignore(): string {
   return `build
 node_modules


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
Remove .npmrc generation from superface init

## Motivation and Context
We no longer need .npmrc as we have moved to public npm repositories

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
