### PR TITLE
feat(generate): Allow every type for Result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Changed
 * Export SuperfaceClient type from generated SDK
+* Allow every type for Result in generated SDK
 
 ## [0.0.10] - 2021-04-26
 

--- a/fixtures/install/playground/superface/types/starwars/character-information.ts
+++ b/fixtures/install/playground/superface/types/starwars/character-information.ts
@@ -1,15 +1,13 @@
 import { typeHelper, TypedProfile } from '@superfaceai/one-sdk';
-/** Starwars **/
-export interface RetrieveCharacterInformationInput {
+export type RetrieveCharacterInformationInput = {
     characterName?: unknown;
-}
-/** Starwars **/
-export interface RetrieveCharacterInformationResult {
+};
+export type RetrieveCharacterInformationResult = {
     height?: unknown;
     weight?: unknown;
     yearOfBirth?: unknown;
-}
-export const profile = {
+};
+const profile = {
     "RetrieveCharacterInformation": typeHelper<RetrieveCharacterInformationInput, RetrieveCharacterInformationResult>()
 };
 export type StarwarsCharacterInformationProfile = TypedProfile<typeof profile>;

--- a/fixtures/install/playground/superface/types/starwars/character-information.ts
+++ b/fixtures/install/playground/superface/types/starwars/character-information.ts
@@ -8,6 +8,7 @@ export type RetrieveCharacterInformationResult = {
     yearOfBirth?: unknown;
 };
 const profile = {
+    /** Starwars **/
     "RetrieveCharacterInformation": typeHelper<RetrieveCharacterInformationInput, RetrieveCharacterInformationResult>()
 };
 export type StarwarsCharacterInformationProfile = TypedProfile<typeof profile>;

--- a/src/common/http.ts
+++ b/src/common/http.ts
@@ -30,6 +30,7 @@ export enum ContentType {
   PROFILE = 'application/vnd.superface.profile',
   AST = 'application/vnd.superface.profile+json',
 }
+
 export function getStoreUrl(): string {
   const envUrl = process.env.SUPERFACE_API_URL;
 

--- a/src/logic/generate.ts
+++ b/src/logic/generate.ts
@@ -48,7 +48,6 @@ export function isDocumentedStructure(
   return 'title' in structure;
 }
 
-export type UsecaseOutput = ProfileOutput['usecases'][number];
 export function createUsecaseTypes(
   usecase: ProfileOutput['usecases'][number],
   untypedType: 'any' | 'unknown'

--- a/src/logic/generate.ts
+++ b/src/logic/generate.ts
@@ -77,7 +77,6 @@ export function createUsecaseTypes(
     const doc = isDocumentedStructure(usecase.result)
       ? { title: usecase.result.title, description: usecase.result.description }
       : undefined;
-    console.log(usecase.result);
     results = [
       addDoc(
         typeAlias(


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Instead of generating an interface for Result, generates type alias that can take any shape

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Only object results were supported so far

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [X] I have read the **CONTRIBUTION_GUIDE** document.
- [X] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
