### PR TITLE
fix: coma separated providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ OPTIONS
 EXAMPLES
   $ superface install
   $ superface install sms/service@1.0
-  $ superface install sms/service@1.0 --providers twilio
+  $ superface install sms/service@1.0 --providers twilio tyntec
   $ superface install sms/service@1.0 -p twilio
   $ superface install --local sms/service.supr
 ```

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -223,7 +223,7 @@ describe('Install CLI command', () => {
       );
     }, 10000);
 
-    it('calls install profiles correctly - providers separated by coma', async () => {
+    it('calls install profiles correctly - providers separated by coma and space', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
       mocked(installProvider).mockResolvedValue(undefined);
       const profileName = 'starwars/character-information';
@@ -232,11 +232,7 @@ describe('Install CLI command', () => {
         Install.run([
           profileName,
           '-p',
-          'tyntec,',
-          ' twilio, ',
-          ', dhl-unified , ',
-          ' github ',
-          ' made.up',
+          ',tyntec, twilio, , dhl-unified ,,github,made.up,',
         ])
       ).resolves.toBeUndefined();
 

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -23,12 +23,9 @@ const parseProviders = (
   if (!providers) {
     return [];
   }
-  const splitted: string[] = [];
-  providers.forEach(provider => {
-    splitted.push(...provider.split(','));
-  });
 
-  return splitted
+  return providers
+    .flatMap(provider => provider.split(','))
     .map(p => p.trim())
     .filter(p => {
       if (p === '') {
@@ -102,10 +99,10 @@ export default class Install extends Command {
     '$ superface install --local sms/service.supr',
   ];
 
-  private warnCallback?= (message: string) =>
+  private warnCallback? = (message: string) =>
     this.log('⚠️  ' + yellow(message));
 
-  private logCallback?= (message: string) => this.log(grey(message));
+  private logCallback? = (message: string) => this.log(grey(message));
 
   async run(): Promise<void> {
     const { args, flags } = this.parse(Install);

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -23,21 +23,17 @@ const parseProviders = (
   if (!providers) {
     return [];
   }
+  const splitted: string[] = [];
+  providers.forEach(provider => {
+    splitted.push(...provider.split(','));
+  });
 
-  return providers
-    .map(provider => {
-      //Remove whitespaces and , chracters
-      let trimmed = provider.trim();
-      if (trimmed.startsWith(',')) {
-        trimmed = trimmed.substring(1);
-      }
-      if (trimmed.endsWith(',')) {
-        trimmed = trimmed.substring(0, trimmed.length - 1);
-      }
-
-      return trimmed.trim();
-    })
+  return splitted
+    .map(p => p.trim())
     .filter(p => {
+      if (p === '') {
+        return false;
+      }
       if (!isValidProviderName(p)) {
         options?.warnCb?.(`Invalid provider name: ${p}`);
 
@@ -106,10 +102,10 @@ export default class Install extends Command {
     '$ superface install --local sms/service.supr',
   ];
 
-  private warnCallback?= (message: string) =>
+  private warnCallback? = (message: string) =>
     this.log('⚠️  ' + yellow(message));
 
-  private logCallback?= (message: string) => this.log(grey(message));
+  private logCallback? = (message: string) => this.log(grey(message));
 
   async run(): Promise<void> {
     const { args, flags } = this.parse(Install);

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -97,15 +97,15 @@ export default class Install extends Command {
   static examples = [
     '$ superface install',
     '$ superface install sms/service@1.0',
-    '$ superface install sms/service@1.0 --providers twilio',
+    '$ superface install sms/service@1.0 --providers twilio tyntec',
     '$ superface install sms/service@1.0 -p twilio',
     '$ superface install --local sms/service.supr',
   ];
 
-  private warnCallback? = (message: string) =>
+  private warnCallback?= (message: string) =>
     this.log('⚠️  ' + yellow(message));
 
-  private logCallback? = (message: string) => this.log(grey(message));
+  private logCallback?= (message: string) => this.log(grey(message));
 
   async run(): Promise<void> {
     const { args, flags } = this.parse(Install);


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR adds parsing of coma (only coma not space) separated provider names

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
