### PR TITLE
chore: hide unused commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,38 +47,8 @@ npm install --global @superfaceai/cli
 ## Usage
 
   <!-- commands -->
-* [`superface compile FILE`](#superface-compile-file)
 * [`superface configure PROVIDERNAME`](#superface-configure-providername)
-* [`superface create DOCUMENTINFO`](#superface-create-documentinfo)
 * [`superface install [PROFILEID]`](#superface-install-profileid)
-* [`superface lint FILE`](#superface-lint-file)
-
-## `superface compile FILE`
-
-Compiles the given profile or map.
-
-```
-USAGE
-  $ superface compile FILE
-
-OPTIONS
-  -c, --compact                        Use compact JSON representation of the compiled file.
-  -h, --help                           show CLI help
-
-  -o, --output=output                  Specifies directory or filename where the compiled file should be written. `-` is
-                                       stdout, `-2` is stderr. By default, the output is written alongside the input
-                                       file with `.ast.json` suffix added.
-
-  -q, --quiet                          When set to true, disables the shell echo output of init actions.
-
-  -t, --documentType=auto|map|profile  [default: auto] Document type to parse. `auto` attempts to infer from file
-                                       extension.
-
-  --append                             Open output file in append mode instead of truncating it if it exists. Has no
-                                       effect with stdout and stderr streams.
-```
-
-_See code: [src/commands/compile.ts](https://github.com/superfaceai/cli/tree/main/src/commands/compile.ts)_
 
 ## `superface configure PROVIDERNAME`
 
@@ -107,47 +77,6 @@ EXAMPLES
 
 _See code: [src/commands/configure.ts](https://github.com/superfaceai/cli/tree/main/src/commands/configure.ts)_
 
-## `superface create DOCUMENTINFO`
-
-Creates empty map and profile on a local filesystem.
-
-```
-USAGE
-  $ superface create DOCUMENTINFO
-
-ARGUMENTS
-  DOCUMENTINFO  Two arguments containing informations about the document.
-                1. Document Type (optional) - type of document that will be created (profile or map), if not specified,
-                utility will create both
-                2. Document Name - name of a file that will be created
-
-OPTIONS
-  -h, --help               show CLI help
-  -p, --provider=provider  Name of a Provider
-  -q, --quiet              When set to true, disables the shell echo output of init actions.
-
-  -s, --scan=scan          When number provided, scan for super.json outside cwd within range represented by this
-                           number.
-
-  -t, --variant=variant    Variant of a map
-
-  -u, --usecase=usecase    Usecases that profile or map contains
-
-  -v, --version=version    [default: 1.0.0] Version of a profile
-
-  --template=empty|pubs    [default: empty] Template to initialize the usecases and maps with
-
-EXAMPLES
-  $ superface create profile sms/service
-  $ superface create profile sms/service -u SendSMS ReceiveSMS
-  $ superface create map sms/service -p twilio
-  $ superface create map sms/service -p twilio -u SendSMS ReceiveSMS
-  $ superface create sms/service -p twilio -u SendSMS ReceiveSMS
-  $ superface create sms/service -p twilio -t bugfix -v 1.1-rev133 -u SendSMS ReceiveSMS
-```
-
-_See code: [src/commands/create.ts](https://github.com/superfaceai/cli/tree/main/src/commands/create.ts)_
-
 ## `superface install [PROFILEID]`
 
 Automatically initializes superface directory in current working directory if needed, communicates with Superface Store API, stores profiles and compiled files to a local system. Install without any arguments tries to install profiles and providers listed in super.json
@@ -168,7 +97,6 @@ OPTIONS
 
   -s, --scan=scan            When number provided, scan for super.json outside cwd within range represented by this
                              number.
-  -t, --types                When set to true, generates TypeScript typings for profiles
 
 EXAMPLES
   $ superface install
@@ -179,37 +107,6 @@ EXAMPLES
 ```
 
 _See code: [src/commands/install.ts](https://github.com/superfaceai/cli/tree/main/src/commands/install.ts)_
-
-## `superface lint FILE`
-
-Lints a map or profile file. Outputs the linter issues to STDOUT by default.
-
-```
-USAGE
-  $ superface lint FILE
-
-OPTIONS
-  -f, --outputFormat=long|short|json   [default: long] Output format to use to display errors and warnings.
-  -h, --help                           show CLI help
-
-  -o, --output=output                  [default: -] Filename where the output will be written. `-` is stdout, `-2` is
-                                       stderr.
-
-  -q, --quiet                          When set to true, disables output of warnings.
-
-  -t, --documentType=auto|map|profile  [default: auto] Document type to parse. `auto` attempts to infer from file
-                                       extension.
-
-  -v, --validate                       Validate maps to specific profile.
-
-  --append                             Open output file in append mode instead of truncating it if it exists. Has no
-                                       effect with stdout and stderr streams.
-
-DESCRIPTION
-  Linter ends with non zero exit code if errors are found.
-```
-
-_See code: [src/commands/lint.ts](https://github.com/superfaceai/cli/tree/main/src/commands/lint.ts)_
 <!-- commandsstop -->
 
 ## Security

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -1,6 +1,7 @@
 import { flags } from '@oclif/command';
 import { Source } from '@superfaceai/parser';
 import { parseEnvFeatures } from '@superfaceai/parser/dist/language/syntax/features';
+import { yellow } from 'chalk';
 import { basename, join as joinPath } from 'path';
 
 import { Command } from '../common/command.abstract';
@@ -15,6 +16,9 @@ import { isDirectoryQuiet, readFile } from '../common/io';
 import { OutputStream } from '../common/output-stream';
 
 export default class Compile extends Command {
+  // hide the command from help
+  static hidden = true;
+
   static description = 'Compiles the given profile or map.';
 
   static flags = {
@@ -44,7 +48,15 @@ export default class Compile extends Command {
   static strict = false;
 
   async run(): Promise<void> {
+    //Warn user
+    this.warn(
+      yellow(
+        'You are using a hidden command. This command is not intended for public consumption yet. It might be broken, hard to use or simply redundant. Tread with care.'
+      )
+    );
+
     const DEFAULT_EXTENSION = '.ast.json';
+
     // TODO: This should be called in parser automatically
     parseEnvFeatures();
 

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -19,6 +19,9 @@ import { initSuperface } from '../logic/init';
 import { detectSuperJson } from '../logic/install';
 
 export default class Create extends Command {
+  // hide the command from help
+  static hidden = true;
+
   static strict = false;
 
   static description = 'Creates empty map and profile on a local filesystem.';
@@ -80,6 +83,13 @@ export default class Create extends Command {
 
   async run(): Promise<void> {
     const { argv, flags } = this.parse(Create);
+
+    //Warn user
+    this.warn(
+      yellow(
+        'You are using a hidden command. This command is not intended for public consumption yet. It might be broken, hard to use or simply redundant. Tread with care.'
+      )
+    );
 
     if (flags.quiet) {
       this.logCallback = undefined;

--- a/src/commands/install.integration.test.ts
+++ b/src/commands/install.integration.test.ts
@@ -16,7 +16,7 @@ describe('Install CLI command', () => {
   const PROFILE = {
     scope: 'starwars',
     name: 'character-information',
-    version: '1.0.1',
+    version: '1.0.2',
   };
 
   const FIXTURE = {

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -1,4 +1,5 @@
 import { flags } from '@oclif/command';
+import { yellow } from 'chalk';
 
 import { Command } from '../common/command.abstract';
 import { developerError, userError } from '../common/error';
@@ -17,6 +18,9 @@ import {
 type OutputFormatFlag = 'long' | 'short' | 'json';
 
 export default class Lint extends Command {
+  // hide the command from help
+  static hidden = true;
+
   static description =
     'Lints a map or profile file. Outputs the linter issues to STDOUT by default.\nLinter ends with non zero exit code if errors are found.';
 
@@ -81,6 +85,13 @@ export default class Lint extends Command {
 
   async run(): Promise<void> {
     const { argv, flags } = this.parse(Lint);
+
+    //Warn user
+    this.warn(
+      yellow(
+        'You are using a hidden command. This command is not intended for public consumption yet. It might be broken, hard to use or simply redundant. Tread with care.'
+      )
+    );
 
     const outputStream = new OutputStream(flags.output, {
       append: flags.append,


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR hides commands which are not related to profile/map/provider consuming

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
