### PR TITLE
chore: do not generate build folder and gitignore

### DIFF
--- a/src/commands/init.integration.test.ts
+++ b/src/commands/init.integration.test.ts
@@ -1,7 +1,6 @@
 import { join as joinPath } from 'path';
 
 import {
-  BUILD_DIR,
   EXTENSIONS,
   GRID_DIR,
   SUPER_PATH,
@@ -33,18 +32,16 @@ describe('Init CLI command', () => {
   it('initializes base folder', async () => {
     await expect(Init.run([testInitFolderPath])).resolves.toBeUndefined();
 
-    const expectedFiles = [joinPath(SUPERFACE_DIR, '.gitignore'), SUPER_PATH];
+    const expectedFiles = [SUPER_PATH];
 
-    const expectedDirectories = [SUPERFACE_DIR, BUILD_DIR, TYPES_DIR, GRID_DIR];
+    const expectedDirectories = [SUPERFACE_DIR, TYPES_DIR, GRID_DIR];
 
     expect(stdout.output).toContain(
       `$ echo '<README.md template>' > 'fixtures/playgrounds/test/README.md'
 $ mkdir 'fixtures/playgrounds/test/superface'
 $ echo '<initial super.json>' > 'fixtures/playgrounds/test/superface/super.json'
-$ echo '<.gitignore template>' > 'fixtures/playgrounds/test/superface/.gitignore'
 $ mkdir 'fixtures/playgrounds/test/superface/grid'
 $ mkdir 'fixtures/playgrounds/test/superface/types'
-$ mkdir 'fixtures/playgrounds/test/superface/build'
 `
     );
 
@@ -66,9 +63,9 @@ $ mkdir 'fixtures/playgrounds/test/superface/build'
   it('initializes base folder with quiet mode', async () => {
     await expect(Init.run([testInitFolderPath, '-q'])).resolves.toBeUndefined();
 
-    const expectedFiles = [joinPath(SUPERFACE_DIR, '.gitignore'), SUPER_PATH];
+    const expectedFiles = [SUPER_PATH];
 
-    const expectedDirectories = [SUPERFACE_DIR, BUILD_DIR, TYPES_DIR, GRID_DIR];
+    const expectedDirectories = [SUPERFACE_DIR, TYPES_DIR, GRID_DIR];
 
     expect(stdout.output).not.toContain(
       "$ mkdir 'fixtures/playgrounds/test/superface"

--- a/src/commands/play.integration.test.ts
+++ b/src/commands/play.integration.test.ts
@@ -83,7 +83,6 @@ describe('Play CLI command', () => {
       `${createdPlayground.name}.foo.suma`,
       `${createdPlayground.name}.bar.suma`,
       joinPath('superface', 'super.json'),
-      joinPath('superface', '.gitignore'),
       joinPath('superface', 'package.json'),
       joinPath('superface', 'play', `${createdPlayground.name}.play.ts`),
     ].map(f => joinPath(createdPlayground.path, f));
@@ -95,13 +94,10 @@ describe('Play CLI command', () => {
       `$ echo '<initial super.json>' > '${expectedFiles[3]}'`
     );
     expect(stdout.output).toContain(
-      `$ echo '<.gitignore template>' > '${expectedFiles[4]}'`
+      `$ echo '<package.json template>' > '${expectedFiles[4]}'`
     );
     expect(stdout.output).toContain(
-      `$ echo '<package.json template>' > '${expectedFiles[5]}'`
-    );
-    expect(stdout.output).toContain(
-      `$ echo '<play.ts template>' > '${expectedFiles[6]}'`
+      `$ echo '<play.ts template>' > '${expectedFiles[5]}'`
     );
     expect(stdout.output).toContain(
       `-> Created ${expectedFiles[0]} (name = "create_test", version = "1.0.0")`
@@ -178,7 +174,6 @@ describe('Play CLI command', () => {
       `${createdPlayground.name}.bar.suma`,
       joinPath('superface', 'super.json'),
       joinPath('superface', 'package.json'),
-      joinPath('superface', '.gitignore'),
       joinPath('superface', 'play', `${createdPlayground.name}.play.ts`),
     ].map(f => joinPath(createdPlayground.path, f));
 

--- a/src/logic/init.test.ts
+++ b/src/logic/init.test.ts
@@ -50,13 +50,11 @@ describe('Init logic', () => {
       expect(mkdir).toHaveBeenCalledTimes(1);
       expect(mkdir).toHaveBeenCalledWith(mockAppPath, { recursive: true });
 
-      expect(mkdirQuiet).toHaveBeenCalledTimes(4);
       expect(mkdirQuiet).toHaveBeenNthCalledWith(1, 'test/superface');
       expect(mkdirQuiet).toHaveBeenNthCalledWith(2, 'test/superface/grid');
       expect(mkdirQuiet).toHaveBeenNthCalledWith(3, 'test/superface/types');
-      expect(mkdirQuiet).toHaveBeenNthCalledWith(4, 'test/superface/build');
 
-      expect(writeIfAbsentSpy).toHaveBeenCalledTimes(3);
+      expect(writeIfAbsentSpy).toHaveBeenCalledTimes(2);
       expect(writeIfAbsentSpy).toHaveBeenNthCalledWith(
         1,
         'test/README.md',
@@ -67,12 +65,6 @@ describe('Init logic', () => {
         2,
         'test/superface/super.json',
         expect.anything(),
-        { force: undefined }
-      );
-      expect(writeIfAbsentSpy).toHaveBeenNthCalledWith(
-        3,
-        'test/superface/.gitignore',
-        initTemplate.gitignore,
         { force: undefined }
       );
 

--- a/src/logic/init.ts
+++ b/src/logic/init.ts
@@ -3,7 +3,6 @@ import { parseProfileId } from '@superfaceai/parser';
 import { basename, join as joinPath } from 'path';
 
 import {
-  BUILD_DIR,
   composeUsecaseName,
   GRID_DIR,
   META_FILE,
@@ -91,21 +90,6 @@ export async function initSuperface(
     }
   }
 
-  {
-    const gitignorePath = joinPath(superPath, '.gitignore');
-    const created = await OutputStream.writeIfAbsent(
-      gitignorePath,
-      initTemplate.gitignore,
-      { force: options?.force }
-    );
-
-    if (created) {
-      options?.logCb?.(
-        formatShellLog("echo '<.gitignore template>' >", [gitignorePath])
-      );
-    }
-  }
-
   // create subdirs
   {
     const gridPath = joinPath(appPath, GRID_DIR);
@@ -119,13 +103,6 @@ export async function initSuperface(
     const created = await mkdirQuiet(typesPath);
     if (created) {
       options?.logCb?.(formatShellLog('mkdir', [typesPath]));
-    }
-  }
-  {
-    const buildPath = joinPath(appPath, BUILD_DIR);
-    const created = await mkdirQuiet(buildPath);
-    if (created) {
-      options?.logCb?.(formatShellLog('mkdir', [buildPath]));
     }
   }
 

--- a/src/logic/quickstart.ts
+++ b/src/logic/quickstart.ts
@@ -252,7 +252,6 @@ async function getPromptedValue(
         .filter(row => !row.includes(`${variableName}=`))
         .join('\n');
     } else {
-
       return envContent;
     }
   }

--- a/src/templates/init.ts
+++ b/src/templates/init.ts
@@ -1,10 +1,3 @@
-export function gitignore(): string {
-  return `build
-node_modules
-package-lock.json
-`;
-}
-
 export function readme(name: string): string {
   return `# ${name}
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR removes generation of gitignore file and build folder during superface init.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
