### PR TITLE
chore: Make generated types more specific

### DIFF
--- a/src/logic/generate.test.ts
+++ b/src/logic/generate.test.ts
@@ -39,9 +39,13 @@ describe('Code Generation', () => {
       const result = generateTypingsForProfile(ast);
 
       expect(result).toMatch(/import.*@superfaceai\/one-sdk/);
-      expect(result).toMatch('export type RetrieveCharacterInformationInput');
+      expect(result).toMatch(
+        'export type StarwarsCharacterInformationRetrieveCharacterInformationInput'
+      );
       expect(result).toMatch(/characterName: string;?$/m);
-      expect(result).toMatch('export type RetrieveCharacterInformationResult');
+      expect(result).toMatch(
+        'export type StarwarsCharacterInformationRetrieveCharacterInformationResult'
+      );
       expect(result).toMatch(/name: string;?$/m);
       expect(result).toMatch(/height\?: string | null;?$/m);
       expect(result).toMatch(/weight: string | null;?$/m);

--- a/src/logic/generate.ts
+++ b/src/logic/generate.ts
@@ -58,7 +58,7 @@ export function generateTypingsForProfile(
       : profileAST.header.name;
   const output = getProfileOutput(profileAST);
   const inputTypes = output.usecases.flatMap(usecase =>
-    createUsecaseTypes(usecase, 'unknown')
+    createUsecaseTypes(profileName, usecase, 'unknown')
   );
 
   const statements = [

--- a/src/logic/generate.utils.ts
+++ b/src/logic/generate.utils.ts
@@ -581,6 +581,7 @@ export function createProfileType(
  * > }
  */
 export function createUsecaseTypes(
+  profileName: string,
   usecase: ProfileOutput['usecases'][number],
   untypedType: 'any' | 'unknown'
 ): Statement[] {
@@ -595,7 +596,7 @@ export function createUsecaseTypes(
     return [
       addDoc(
         typeAlias(
-          capitalize(usecase.useCaseName) + suffix,
+          pascalize(profileName) + camelize(usecase.useCaseName) + suffix,
           variableType(capitalize(usecase.useCaseName), structure, untypedType)
         ),
         doc


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
Makes generated types specific to both profile and usecase

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Generated types were specific only to usecase -> there were conflicts when two profiles had the same usecase name

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
