### PR TITLE
fix: package manager resolution

### DIFF
--- a/src/commands/interactive.install.integration.test.ts
+++ b/src/commands/interactive.install.integration.test.ts
@@ -73,7 +73,7 @@ describe('Interactive install CLI command', () => {
   });
 
   describe('when installing non existing profile', () => {
-    it.skip('installs the profile', async () => {
+    it('installs the profile', async () => {
       const paths = [
         joinPath(
           tempDir,
@@ -111,38 +111,38 @@ describe('Interactive install CLI command', () => {
             //Sendgrid
             { value: DOWN, timeout: 6000 },
             //Confirm slection
-            { value: ENTER, timeout: 100 },
+            { value: ENTER, timeout: 200 },
             //Mailgun
             { value: DOWN, timeout: 6000 },
             //Confirm slection
-            { value: ENTER, timeout: 100 },
+            { value: ENTER, timeout: 200 },
             //Exit
             { value: UP, timeout: 6000 },
             //Confirm slection
-            { value: ENTER, timeout: 100 },
+            { value: ENTER, timeout: 200 },
             //Sendgrid token
             { value: 'sendgridToken', timeout: 10000 },
             { value: ENTER, timeout: 100 },
             //Mailgun username
-            { value: 'username', timeout: 4000 },
+            { value: 'username', timeout: 6000 },
             { value: ENTER, timeout: 100 },
             //Mailgun password
-            { value: 'password', timeout: 4000 },
+            { value: 'password', timeout: 6000 },
             { value: ENTER, timeout: 100 },
             //Confirm dotenv installation
-            { value: ENTER, timeout: 4000 },
+            { value: ENTER, timeout: 6000 },
             //Incorrect SDK token
             {
               value:
                 'XXX_bb064dd57c302911602dd097bc29bedaea6a021c25a66992d475ed959aa526c7_37bce8b5',
-              timeout: 4000,
+              timeout: 6000,
             },
             { value: ENTER, timeout: 100 },
             //Correct SDK token
             {
               value:
                 'sfs_bb064dd57c302911602dd097bc29bedaea6a021c25a66992d475ed959aa526c7_37bce8b5',
-              timeout: 4000,
+              timeout: 6000,
             },
             { value: ENTER, timeout: 500 },
           ],
@@ -246,7 +246,7 @@ describe('Interactive install CLI command', () => {
       ).not.toBeUndefined();
     }, 60000);
 
-    it.skip('installs the profile, overrides existing super.json and updates .env', async () => {
+    it('installs the profile, overrides existing super.json and updates .env', async () => {
       //Existing env
       await OutputStream.writeOnce(
         joinPath(tempDir, '.env'),

--- a/src/commands/interactive.install.integration.test.ts
+++ b/src/commands/interactive.install.integration.test.ts
@@ -73,7 +73,7 @@ describe('Interactive install CLI command', () => {
   });
 
   describe('when installing non existing profile', () => {
-    it('installs the profile', async () => {
+    it.skip('installs the profile', async () => {
       const paths = [
         joinPath(
           tempDir,
@@ -246,7 +246,7 @@ describe('Interactive install CLI command', () => {
       ).not.toBeUndefined();
     }, 60000);
 
-    it('installs the profile, overrides existing super.json and updates .env', async () => {
+    it.skip('installs the profile, overrides existing super.json and updates .env', async () => {
       //Existing env
       await OutputStream.writeOnce(
         joinPath(tempDir, '.env'),

--- a/src/common/package-manager.test.ts
+++ b/src/common/package-manager.test.ts
@@ -1,14 +1,215 @@
 import { mocked } from 'ts-jest/utils';
 
-describe('Quickstart logic', () => {
+describe('Package manager', () => {
   beforeEach(() => {
-    jest.resetModules();
     jest.resetModules();
   });
   afterEach(() => {
     jest.resetAllMocks();
   });
 
+  describe('when checking package.json existence', () => {
+    const mockStderr = jest.fn();
+
+    it('return true when package.json exists', async () => {
+      //Scope imports for every test run to ensure PackageManager isolation
+      const { PackageManager } = await import('./package-manager');
+      const { execShell, exists } = await import('./io');
+      const { join } = await import('path');
+      jest.mock('../common/io');
+      jest.mock('path', () => ({
+        ...jest.requireActual<Record<string, unknown>>('path'),
+        join: jest.fn(),
+      }));
+      mocked(execShell).mockResolvedValue({
+        stderr: '',
+        stdout: 'some/path\n',
+      });
+
+      mocked(join).mockReturnValue('some/path/package.json');
+      mocked(exists).mockResolvedValueOnce(true);
+
+      await expect(
+        PackageManager.packageJsonExists({
+          warnCb: mockStderr,
+        })
+      ).resolves.toEqual(true);
+
+      expect(exists).toHaveBeenCalledWith('some/path/package.json');
+      expect(execShell).toHaveBeenCalledWith('npm prefix');
+
+      expect(mockStderr).not.toHaveBeenCalled();
+    });
+
+    it('return false when package.json does not exist', async () => {
+      //Scope imports for every test run to ensure PackageManager isolation
+      const { PackageManager } = await import('./package-manager');
+      const { execShell, exists } = await import('./io');
+      const { join } = await import('path');
+      jest.mock('../common/io');
+      jest.mock('path', () => ({
+        ...jest.requireActual<Record<string, unknown>>('path'),
+        join: jest.fn(),
+      }));
+      mocked(execShell).mockResolvedValue({
+        stderr: '',
+        stdout: 'some/path\n',
+      });
+
+      mocked(join).mockReturnValue('some/path/package.json');
+      mocked(exists).mockResolvedValueOnce(false);
+
+      await expect(
+        PackageManager.packageJsonExists({
+          warnCb: mockStderr,
+        })
+      ).resolves.toEqual(false);
+
+      expect(exists).toHaveBeenCalledWith('some/path/package.json');
+      expect(execShell).toHaveBeenCalledWith('npm prefix');
+
+      expect(mockStderr).not.toHaveBeenCalled();
+    });
+
+    it('return false when path does not exist', async () => {
+      //Scope imports for every test run to ensure PackageManager isolation
+      const { PackageManager } = await import('./package-manager');
+      const { execShell, exists } = await import('./io');
+      const { join } = await import('path');
+      jest.mock('../common/io');
+      jest.mock('path', () => ({
+        ...jest.requireActual<Record<string, unknown>>('path'),
+        join: jest.fn(),
+      }));
+      mocked(execShell).mockResolvedValue({
+        stderr: 'some-error',
+        stdout: 'some/path\n',
+      });
+
+      mocked(join).mockReturnValue('some/path/package.json');
+      mocked(exists).mockResolvedValueOnce(true);
+
+      await expect(
+        PackageManager.packageJsonExists({
+          warnCb: mockStderr,
+        })
+      ).resolves.toEqual(false);
+
+      expect(exists).not.toHaveBeenCalled();
+      expect(execShell).toHaveBeenCalledWith('npm prefix');
+
+      expect(mockStderr).toHaveBeenCalledWith(
+        'Shell command "npm prefix" responded with: "some-error"'
+      );
+    });
+  });
+
+  describe('when initializing package manager', () => {
+    const mockStderr = jest.fn();
+    const mockStdout = jest.fn();
+
+    it('returns true for npm', async () => {
+      //Scope imports for every test run to ensure PackageManager isolation
+      const { PackageManager } = await import('./package-manager');
+      const { execShell, exists } = await import('./io');
+      const { join } = await import('path');
+      jest.mock('../common/io');
+      jest.mock('path', () => ({
+        ...jest.requireActual<Record<string, unknown>>('path'),
+        join: jest.fn(),
+      }));
+      mocked(execShell)
+        .mockResolvedValueOnce({ stderr: '', stdout: 'some/path\n' })
+        .mockResolvedValueOnce({ stderr: '', stdout: 'some-logs' });
+
+      mocked(join).mockReturnValue('some/path/package-lock.json');
+      //Package.lock does not exist
+      mocked(exists).mockResolvedValue(false);
+
+      await expect(
+        PackageManager.init('npm', {
+          logCb: mockStdout,
+          warnCb: mockStderr,
+        })
+      ).resolves.toEqual(true);
+
+      expect(exists).toHaveBeenCalledWith('some/path/package-lock.json');
+      expect(execShell).toHaveBeenCalledWith('npm prefix');
+      expect(execShell).toHaveBeenCalledWith('npm init -y');
+
+      expect(mockStderr).not.toHaveBeenCalled();
+      expect(mockStdout).toHaveBeenCalledWith('some-logs');
+    });
+
+    it('returns true for yarn', async () => {
+      //Scope imports for every test run to ensure PackageManager isolation
+      const { PackageManager } = await import('./package-manager');
+      const { execShell, exists } = await import('./io');
+      const { join } = await import('path');
+      jest.mock('../common/io');
+      jest.mock('path', () => ({
+        ...jest.requireActual<Record<string, unknown>>('path'),
+        join: jest.fn(),
+      }));
+      mocked(execShell)
+        .mockResolvedValueOnce({ stderr: '', stdout: 'some/path\n' })
+        .mockResolvedValueOnce({ stderr: 'some warning', stdout: '' });
+
+      mocked(join).mockReturnValue('some/path/yarn.lock');
+      //Package.lock does not exist
+      mocked(exists).mockResolvedValue(false);
+
+      await expect(
+        PackageManager.init('yarn', {
+          logCb: mockStdout,
+          warnCb: mockStderr,
+        })
+      ).resolves.toEqual(true);
+
+      expect(exists).toHaveBeenCalledWith('some/path/yarn.lock');
+      expect(execShell).toHaveBeenCalledWith('npm prefix');
+      expect(execShell).toHaveBeenCalledWith('yarn init -y');
+
+      expect(mockStderr).toHaveBeenCalledWith(
+        'Shell command "yarn init -y" responded with: "some warning"'
+      );
+      expect(mockStdout).not.toHaveBeenCalled();
+    });
+
+    it('returns false when pm is already initialized', async () => {
+      //Scope imports for every test run to ensure PackageManager isolation
+      const { PackageManager } = await import('./package-manager');
+      const { execShell, exists } = await import('./io');
+      const { join } = await import('path');
+      jest.mock('../common/io');
+      jest.mock('path', () => ({
+        ...jest.requireActual<Record<string, unknown>>('path'),
+        join: jest.fn(),
+      }));
+      mocked(execShell)
+        .mockResolvedValueOnce({ stderr: '', stdout: 'some/path\n' })
+        .mockResolvedValueOnce({ stderr: '', stdout: '' });
+
+      mocked(join).mockReturnValue('some/path/yarn.lock');
+      //Package.lock does not exist
+      mocked(exists)
+        //Yarn.lock exist
+        .mockResolvedValue(true);
+
+      await expect(
+        PackageManager.init('yarn', {
+          logCb: mockStdout,
+          warnCb: mockStderr,
+        })
+      ).resolves.toEqual(false);
+
+      expect(exists).toHaveBeenCalledWith('some/path/yarn.lock');
+      expect(execShell).toHaveBeenCalledWith('npm prefix');
+
+      expect(mockStderr).toHaveBeenCalledWith('yarn already initialized.');
+      expect(mockStdout).not.toHaveBeenCalled();
+    });
+  });
   describe('when installing package', () => {
     const mockStdout = jest.fn();
     const mockStderr = jest.fn();
@@ -19,12 +220,15 @@ describe('Quickstart logic', () => {
       const { execShell, exists } = await import('./io');
       const { join } = await import('path');
       jest.mock('../common/io');
-      jest.mock('path');
+      jest.mock('path', () => ({
+        ...jest.requireActual<Record<string, unknown>>('path'),
+        join: jest.fn(),
+      }));
       mocked(execShell)
         .mockResolvedValueOnce({ stderr: '', stdout: 'some/path\n' })
         .mockResolvedValueOnce({ stderr: '', stdout: '' });
       mocked(join).mockReturnValue('some/path/yarn.lock');
-      mocked(exists).mockResolvedValueOnce(true);
+      mocked(exists).mockResolvedValueOnce(true).mockResolvedValueOnce(true);
 
       await expect(
         PackageManager.installPackage('@superfaceai/one-sdk', {
@@ -47,7 +251,10 @@ describe('Quickstart logic', () => {
       const { execShell, exists } = await import('./io');
       const { join } = await import('path');
       jest.mock('../common/io');
-      jest.mock('path');
+      jest.mock('path', () => ({
+        ...jest.requireActual<Record<string, unknown>>('path'),
+        join: jest.fn(),
+      }));
       mocked(execShell)
         .mockResolvedValueOnce({ stderr: '', stdout: 'some/path\n' })
         .mockResolvedValueOnce({ stderr: '', stdout: '' })
@@ -96,7 +303,10 @@ describe('Quickstart logic', () => {
       const { execShell, exists } = await import('./io');
       const { join } = await import('path');
       jest.mock('../common/io');
-      jest.mock('path');
+      jest.mock('path', () => ({
+        ...jest.requireActual<Record<string, unknown>>('path'),
+        join: jest.fn(),
+      }));
       mocked(execShell)
         .mockResolvedValueOnce({ stderr: '', stdout: 'some/path\n' })
         .mockResolvedValueOnce({
@@ -104,14 +314,14 @@ describe('Quickstart logic', () => {
           stdout: 'test out',
         });
       mocked(join).mockReturnValue('some/path/yarn.lock');
-      mocked(exists).mockResolvedValueOnce(true);
+      mocked(exists).mockResolvedValueOnce(true).mockResolvedValueOnce(true);
 
       await expect(
         PackageManager.installPackage('@superfaceai/one-sdk', {
           logCb: mockStdout,
           warnCb: mockStderr,
         })
-      ).resolves.toEqual(false);
+      ).resolves.toEqual(true);
 
       expect(exists).toHaveBeenCalledWith('some/path/yarn.lock');
       expect(execShell).toHaveBeenCalledWith('yarn add @superfaceai/one-sdk');
@@ -128,7 +338,10 @@ describe('Quickstart logic', () => {
       const { execShell, exists } = await import('./io');
       const { join } = await import('path');
       jest.mock('../common/io');
-      jest.mock('path');
+      jest.mock('path', () => ({
+        ...jest.requireActual<Record<string, unknown>>('path'),
+        join: jest.fn(),
+      }));
       mocked(execShell)
         .mockResolvedValueOnce({
           stderr: 'npm prefix err',
@@ -164,12 +377,18 @@ describe('Quickstart logic', () => {
       const { execShell, exists } = await import('./io');
       const { join } = await import('path');
       jest.mock('../common/io');
-      jest.mock('path');
+      jest.mock('path', () => ({
+        ...jest.requireActual<Record<string, unknown>>('path'),
+        join: jest.fn(),
+      }));
       mocked(execShell)
         .mockResolvedValueOnce({ stderr: '', stdout: 'some/path\n' })
         .mockResolvedValueOnce({ stderr: '', stdout: '' });
       mocked(join).mockReturnValue('some/path/package-lock.json');
-      mocked(exists).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+      mocked(exists)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
 
       await expect(
         PackageManager.installPackage('@superfaceai/one-sdk', {
@@ -194,7 +413,10 @@ describe('Quickstart logic', () => {
       const { execShell, exists } = await import('./io');
       const { join } = await import('path');
       jest.mock('../common/io');
-      jest.mock('path');
+      jest.mock('path', () => ({
+        ...jest.requireActual<Record<string, unknown>>('path'),
+        join: jest.fn(),
+      }));
       mocked(execShell)
         .mockResolvedValueOnce({ stderr: '', stdout: 'some/path\n' })
         .mockResolvedValueOnce({
@@ -202,14 +424,17 @@ describe('Quickstart logic', () => {
           stdout: 'test out',
         });
       mocked(join).mockReturnValue('some/path/package-lock.json');
-      mocked(exists).mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+      mocked(exists)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false)
+        .mockResolvedValueOnce(true);
 
       await expect(
         PackageManager.installPackage('@superfaceai/one-sdk', {
           logCb: mockStdout,
           warnCb: mockStderr,
         })
-      ).resolves.toEqual(false);
+      ).resolves.toEqual(true);
 
       expect(exists).toHaveBeenCalledWith('some/path/package-lock.json');
       expect(execShell).toHaveBeenCalledWith('npm prefix');
@@ -217,7 +442,7 @@ describe('Quickstart logic', () => {
         'npm install @superfaceai/one-sdk'
       );
 
-      expect(mockStdout).not.toHaveBeenCalledWith();
+      expect(mockStdout).toHaveBeenCalledWith('test out');
       expect(mockStderr).toHaveBeenCalledWith(
         'Shell command "npm install @superfaceai/one-sdk" responded with: "test err"'
       );
@@ -229,7 +454,10 @@ describe('Quickstart logic', () => {
       const { execShell, exists } = await import('./io');
       const { join } = await import('path');
       jest.mock('../common/io');
-      jest.mock('path');
+      jest.mock('path', () => ({
+        ...jest.requireActual<Record<string, unknown>>('path'),
+        join: jest.fn(),
+      }));
       mocked(execShell)
         .mockResolvedValueOnce({ stderr: '', stdout: 'some/path\n' })
         .mockResolvedValueOnce({
@@ -237,20 +465,20 @@ describe('Quickstart logic', () => {
           stdout: 'test out',
         });
       mocked(join)
+        .mockReturnValueOnce('some/path/package.json')
         .mockReturnValueOnce('some/path/yarn.lock')
-        .mockReturnValueOnce('some/path/package-lock.json')
-        .mockReturnValueOnce('some/path/package.json');
+        .mockReturnValueOnce('some/path/package-lock.json');
       mocked(exists)
+        .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(false)
-        .mockResolvedValueOnce(false)
-        .mockResolvedValueOnce(true);
+        .mockResolvedValueOnce(false);
 
       await expect(
         PackageManager.installPackage('@superfaceai/one-sdk', {
           logCb: mockStdout,
           warnCb: mockStderr,
         })
-      ).resolves.toEqual(false);
+      ).resolves.toEqual(true);
 
       expect(exists).toHaveBeenCalledWith('some/path/package-lock.json');
       expect(execShell).toHaveBeenCalledWith('npm prefix');
@@ -258,19 +486,22 @@ describe('Quickstart logic', () => {
         'npm install @superfaceai/one-sdk'
       );
 
-      expect(mockStdout).not.toHaveBeenCalledWith();
+      expect(mockStdout).toHaveBeenCalledWith('test out');
       expect(mockStderr).toHaveBeenCalledWith(
         'Shell command "npm install @superfaceai/one-sdk" responded with: "test err"'
       );
     });
 
-    it('installs package with npm - yarn.lock, package-lock.json and package.json not found', async () => {
+    it('does not install package without package.json', async () => {
       //Scope imports for every test run to ensure PackageManager isolation
       const { PackageManager } = await import('./package-manager');
       const { execShell, exists } = await import('./io');
       const { join } = await import('path');
       jest.mock('../common/io');
-      jest.mock('path');
+      jest.mock('path', () => ({
+        ...jest.requireActual<Record<string, unknown>>('path'),
+        join: jest.fn(),
+      }));
       mocked(execShell)
         .mockResolvedValueOnce({ stderr: '', stdout: 'some/path\n' })
         .mockResolvedValueOnce({
@@ -278,9 +509,9 @@ describe('Quickstart logic', () => {
           stdout: 'test out',
         });
       mocked(join)
+        .mockReturnValueOnce('some/path/package.json')
         .mockReturnValueOnce('some/path/yarn.lock')
-        .mockReturnValueOnce('some/path/package-lock.json')
-        .mockReturnValueOnce('some/path/package.json');
+        .mockReturnValueOnce('some/path/package-lock.json');
       mocked(exists)
         .mockResolvedValueOnce(false)
         .mockResolvedValueOnce(false)
@@ -293,14 +524,11 @@ describe('Quickstart logic', () => {
         })
       ).resolves.toEqual(false);
 
-      expect(exists).toHaveBeenCalledWith('some/path/package-lock.json');
+      expect(exists).toHaveBeenCalledWith('some/path/package.json');
       expect(execShell).toHaveBeenCalledWith('npm prefix');
-      expect(execShell).toHaveBeenCalledWith(
-        'npm install @superfaceai/one-sdk'
-      );
 
       expect(mockStderr).toHaveBeenCalledWith(
-        'Shell command "npm install @superfaceai/one-sdk" responded with: "test err"'
+        'Unable to install package @superfaceai/one-sdk without initialized package.json'
       );
     });
   });

--- a/src/common/package-manager.ts
+++ b/src/common/package-manager.ts
@@ -22,11 +22,8 @@ export class PackageManager {
 
       return;
     }
-    if (process.cwd() === npmPrefix.stdout.trim()) {
-      PackageManager.path = './';
-    } else {
-      PackageManager.path = relative(process.cwd(), npmPrefix.stdout.trim());
-    }
+    PackageManager.path =
+      relative(process.cwd(), npmPrefix.stdout.trim()) || './';
 
     return PackageManager.path;
   }

--- a/src/common/package-manager.ts
+++ b/src/common/package-manager.ts
@@ -22,7 +22,11 @@ export class PackageManager {
 
       return;
     }
-    PackageManager.path = relative(process.cwd(), npmPrefix.stdout.trim());
+    if (process.cwd() === npmPrefix.stdout.trim()) {
+      PackageManager.path = './';
+    } else {
+      PackageManager.path = relative(process.cwd(), npmPrefix.stdout.trim());
+    }
 
     return PackageManager.path;
   }

--- a/src/common/package-manager.ts
+++ b/src/common/package-manager.ts
@@ -105,15 +105,16 @@ export class PackageManager {
       warnCb?: LogCallback;
     }
   ): Promise<boolean> {
-    const pm = await PackageManager.getUsedPm({ warnCb: options?.warnCb });
-
-    if (!pm) {
+    if (
+      !(await PackageManager.packageJsonExists({ warnCb: options?.warnCb }))
+    ) {
       options?.warnCb?.(
         `Unable to install package ${packageName} without initialized package.json`
       );
 
       return false;
     }
+    const pm = await PackageManager.getUsedPm({ warnCb: options?.warnCb });
 
     const command =
       pm === 'yarn' ? `yarn add ${packageName}` : `npm install ${packageName}`;

--- a/src/common/package-manager.ts
+++ b/src/common/package-manager.ts
@@ -5,12 +5,13 @@ import { LogCallback } from './log';
 
 export class PackageManager {
   private static usedPackageManager: 'npm' | 'yarn' | undefined = undefined;
+  private static path: string | undefined = undefined;
 
-  private static async getUsedPm(options?: {
+  private static async getPath(options?: {
     warnCb?: LogCallback;
-  }): Promise<'npm' | 'yarn' | undefined> {
-    if (PackageManager.usedPackageManager) {
-      return PackageManager.usedPackageManager;
+  }): Promise<string | undefined> {
+    if (PackageManager.path) {
+      return PackageManager.path;
     }
     const npmPrefix = await execShell(`npm prefix`);
 
@@ -21,7 +22,32 @@ export class PackageManager {
 
       return;
     }
-    const path = relative(process.cwd(), npmPrefix.stdout.trim());
+    PackageManager.path = relative(process.cwd(), npmPrefix.stdout.trim());
+
+    return PackageManager.path;
+  }
+
+  public static async packageJsonExists(options?: {
+    warnCb?: LogCallback;
+  }): Promise<boolean> {
+    const path = await PackageManager.getPath(options);
+    if (path && (await exists(join(path, 'package.json')))) {
+      return true;
+    }
+
+    return false;
+  }
+
+  public static async getUsedPm(options?: {
+    warnCb?: LogCallback;
+  }): Promise<'npm' | 'yarn' | undefined> {
+    if (PackageManager.usedPackageManager) {
+      return PackageManager.usedPackageManager;
+    }
+    const path = await PackageManager.getPath(options);
+    if (!path) {
+      return;
+    }
 
     //Try to find yarn.lock
     if (await exists(join(path, 'yarn.lock'))) {
@@ -37,16 +63,39 @@ export class PackageManager {
       return 'npm';
     }
 
-    //Try to find package.json
-    if (await exists(join(path, 'package.json'))) {
-      PackageManager.usedPackageManager = 'npm';
+    return;
+  }
 
-      return 'npm';
+  public static async init(
+    initPm: 'yarn' | 'npm',
+    options?: {
+      logCb?: LogCallback;
+      warnCb?: LogCallback;
+    }
+  ): Promise<boolean> {
+    const pm = await PackageManager.getUsedPm({ warnCb: options?.warnCb });
+    if (pm && pm === initPm) {
+      options?.warnCb?.(`${pm} already initialized.`);
+
+      return false;
+    }
+    const command = initPm === 'yarn' ? `yarn init -y` : `npm init -y`;
+
+    const result = await execShell(command);
+    if (result.stderr !== '') {
+      options?.warnCb?.(
+        `Shell command "${command}" responded with: "${result.stderr.trimEnd()}"`
+      );
     }
 
-    options?.warnCb?.('Unable to locate package.json');
+    if (result.stdout !== '') {
+      options?.logCb?.(result.stdout.trimEnd());
+    }
 
-    return;
+    //Set used PM after init
+    PackageManager.usedPackageManager = initPm;
+
+    return true;
   }
 
   public static async installPackage(
@@ -58,6 +107,14 @@ export class PackageManager {
   ): Promise<boolean> {
     const pm = await PackageManager.getUsedPm({ warnCb: options?.warnCb });
 
+    if (!pm) {
+      options?.warnCb?.(
+        `Unable to install package ${packageName} without initialized package.json`
+      );
+
+      return false;
+    }
+
     const command =
       pm === 'yarn' ? `yarn add ${packageName}` : `npm install ${packageName}`;
 
@@ -66,9 +123,8 @@ export class PackageManager {
       options?.warnCb?.(
         `Shell command "${command}" responded with: "${result.stderr.trimEnd()}"`
       );
-
-      return false;
     }
+
     if (result.stdout !== '') {
       options?.logCb?.(result.stdout.trimEnd());
     }

--- a/src/common/package-manager.ts
+++ b/src/common/package-manager.ts
@@ -1,4 +1,4 @@
-import { join, relative } from 'path';
+import { join, normalize, relative } from 'path';
 
 import { execShell, exists } from './io';
 import { LogCallback } from './log';
@@ -23,7 +23,7 @@ export class PackageManager {
       return;
     }
     PackageManager.path =
-      relative(process.cwd(), npmPrefix.stdout.trim()) || './';
+      relative(process.cwd(), npmPrefix.stdout.trim()) || normalize('./');
 
     return PackageManager.path;
   }

--- a/src/logic/quickstart.test.ts
+++ b/src/logic/quickstart.test.ts
@@ -199,6 +199,8 @@ describe('Quickstart logic', () => {
         .mockResolvedValueOnce({ value: 'mailgunUsername' })
         //Set mailgun password
         .mockResolvedValueOnce({ value: 'mailgunPassword' })
+        //Init PM
+        .mockResolvedValueOnce({ pm: 'yarn' })
         //Install dotenv
         .mockResolvedValueOnce({ continue: true })
         //Set SDK token
@@ -335,7 +337,8 @@ describe('Quickstart logic', () => {
         .mockResolvedValueOnce({ value: 'mailgunUsername' })
         //Set mailgun password
         .mockResolvedValueOnce({ value: 'mailgunPassword' })
-
+        //Init PM
+        .mockResolvedValueOnce({ pm: 'npm' })
         //Install dotenv
         .mockResolvedValueOnce({ continue: true })
         //Set SDK token
@@ -462,6 +465,8 @@ describe('Quickstart logic', () => {
         .mockResolvedValueOnce({ value: 'mailgunUsername' })
         //Set mailgun password
         .mockResolvedValueOnce({ value: 'mailgunPassword' })
+        //Init PM
+        .mockResolvedValueOnce({ pm: 'yarn' })
         //Install dotenv
         .mockResolvedValueOnce({ continue: true })
         //Set SDK token
@@ -618,6 +623,8 @@ describe('Quickstart logic', () => {
         })
         //Set test digest
         .mockResolvedValueOnce({ value: 'testDigest' })
+        //Init PM
+        .mockResolvedValueOnce({ pm: 'npm' })
         //Install dotenv
         .mockResolvedValueOnce({ continue: true })
         //Set SDK token

--- a/src/logic/quickstart.ts
+++ b/src/logic/quickstart.ts
@@ -274,7 +274,7 @@ export async function interactiveInstall(
       choices: [
         { name: 'Yarn', value: 'yarn' },
         { name: 'NPM', value: 'npm' },
-        { name: 'Exitnstallation', value: 'exit' },
+        { name: 'Exit installation', value: 'exit' },
       ],
     });
 

--- a/src/logic/quickstart.ts
+++ b/src/logic/quickstart.ts
@@ -258,6 +258,36 @@ export async function interactiveInstall(
       );
     }
   }
+  //Check/init package-manager
+  if (!(await PackageManager.packageJsonExists({ warnCb: options?.warnCb }))) {
+    options?.warnCb?.(
+      `Package.json not found in current directory "${process.cwd()}".`
+    );
+    //Prompt user for package manager initialization
+    const response: {
+      pm: 'yarn' | 'npm' | 'exit';
+    } = await inquirer.prompt({
+      name: 'pm',
+      message:
+        'Do you want to initialize package manager ("yes" flag will be used)?',
+      type: 'list',
+      choices: [
+        { name: 'Yarn', value: 'yarn' },
+        { name: 'NPM', value: 'npm' },
+        { name: 'Exitnstallation', value: 'exit' },
+      ],
+    });
+
+    if (response.pm === 'exit') {
+      return;
+    }
+    options?.successCb?.(`\nInitializing package manager "${response.pm}"`);
+
+    await PackageManager.init(response.pm, {
+      logCb: options?.logCb,
+      warnCb: options?.warnCb,
+    });
+  }
   //Install SDK
   options?.successCb?.(`\nInstalling package "@superfaceai/one-sdk"`);
   await PackageManager.installPackage('@superfaceai/one-sdk', {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR fixes problems with package manager during interactive install.

Test are coming.

Logic behind PM resolution:

if we don't find the package.json we ask user to select npm, yarn or exit.This information is used to init selected PM, selected PM is saved on PM static side.After init we try to install packages:
we use PM saved in PM, if undefined we try to find out used PM, if undefined we use NPM.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
