### PR TITLE
Feat/configure local

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ npx @superfaceai/cli install [profileId eg. communication/send-email] -i
 
 ## `superface configure PROVIDERNAME`
 
-Automatically initializes superface directory in current working directory if needed, communicates with Superface Store API, stores provider configuration in super.json
+Configures new provider and map for already installed profile. Provider configuration is dowloaded from a Superface registry or from local file.
 
 ```
 USAGE
@@ -72,17 +72,20 @@ ARGUMENTS
   PROVIDERNAME  Provider name.
 
 OPTIONS
-  -f, --force            When set to true and when provider exists in super.json, overwrites them.
-  -h, --help             show CLI help
-  -l, --local            When set to true, provider name argument is used as a filepath to provider.json file
-  -p, --profile=profile  (required) Specifies profile to associate with provider
-  -q, --quiet            When set to true, disables the shell echo output of init actions.
+  -f, --force                    When set to true and when provider exists in super.json, overwrites them.
+  -h, --help                     show CLI help
+  -p, --profile=profile          (required) Specifies profile to associate with provider
+  -q, --quiet                    When set to true, disables the shell echo output of init actions.
+  --localMap=localMap            Optional filepath to .suma map file
+  --localProvider=localProvider  Optional filepath to provider.json file
+  --no-env                       When set to true command does not prepare security varibles in .env file
 
 EXAMPLES
   $ superface configure twilio -p send-sms
   $ superface configure twilio -p send-sms -q
   $ superface configure twilio -p send-sms -f
-  $ superface configure providers/twilio.provider.json -p send-sms -l
+  $ superface configure twilio -p send-sms --local-provider providers/twilio.provider.json
+  $ superface configure twilio -p send-sms --local-map maps/send-sms.twilio.suma
 ```
 
 _See code: [src/commands/configure.ts](https://github.com/superfaceai/cli/tree/main/src/commands/configure.ts)_

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -5,13 +5,15 @@ import { join as joinPath } from 'path';
 
 import { Command } from '../common/command.abstract';
 import { META_FILE, SUPERFACE_DIR } from '../common/document';
+import { userError } from '../common/error';
+import { exists } from '../common/io';
 import { installProvider } from '../logic/configure';
 import { initSuperface } from '../logic/init';
 import { detectSuperJson } from '../logic/install';
 
 export default class Configure extends Command {
   static description =
-    'Automatically initializes superface directory in current working directory if needed, communicates with Superface Store API, stores provider configuration in super.json';
+    'Configures new provider and map for already installed profile. Provider configuration is dowloaded from a Superface registry or from local file.';
 
   static args = [
     {
@@ -39,11 +41,11 @@ export default class Configure extends Command {
         'When set to true and when provider exists in super.json, overwrites them.',
       default: false,
     }),
-    local: oclifFlags.boolean({
-      char: 'l',
-      description:
-        'When set to true, provider name argument is used as a filepath to provider.json file',
-      default: false,
+    localProvider: oclifFlags.string({
+      description: 'Optional filepath to provider.json file',
+    }),
+    localMap: oclifFlags.string({
+      description: 'Optional filepath to .suma map file',
     }),
   };
 
@@ -51,7 +53,8 @@ export default class Configure extends Command {
     '$ superface configure twilio -p send-sms',
     '$ superface configure twilio -p send-sms -q',
     '$ superface configure twilio -p send-sms -f',
-    '$ superface configure providers/twilio.provider.json -p send-sms -l',
+    '$ superface configure twilio -p send-sms --local-provider providers/twilio.provider.json',
+    '$ superface configure twilio -p send-sms --local-map maps/send-sms.twilio.suma',
   ];
 
   private warnCallback? = (message: string) => this.log(yellow(message));
@@ -65,10 +68,16 @@ export default class Configure extends Command {
       this.logCallback = undefined;
     }
 
-    if (!isValidProviderName(args.providerName) && !flags.local) {
-      this.warnCallback?.('Invalid provider name');
+    if (!isValidProviderName(args.providerName)) {
+      throw userError('Invalid provider name', 1);
+    }
 
-      return;
+    if (flags.localMap && !(await exists(flags.localMap))) {
+      throw userError(`Local path: "${flags.localMap}" does not exist`, 1);
+    }
+
+    if (flags.localProvider && !(await exists(flags.localProvider))) {
+      throw userError(`Local path: "${flags.localProvider}" does not exist`, 1);
     }
 
     let superPath = await detectSuperJson(process.cwd());
@@ -100,7 +109,8 @@ export default class Configure extends Command {
         logCb: this.logCallback,
         warnCb: this.warnCallback,
         force: flags.force,
-        local: flags.local,
+        localMap: flags.localMap,
+        localProvider: flags.localProvider,
         updateEnv: !flags['no-env'],
       },
     });

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -211,7 +211,6 @@ describe('Install CLI command', () => {
           logCb: expect.anything(),
           warnCb: expect.anything(),
           force: false,
-          local: false,
         },
       });
       expect(installProvider).toHaveBeenNthCalledWith(2, {
@@ -223,7 +222,6 @@ describe('Install CLI command', () => {
           logCb: expect.anything(),
           warnCb: expect.anything(),
           force: false,
-          local: false,
         },
       });
     }, 10000);
@@ -262,7 +260,6 @@ describe('Install CLI command', () => {
           logCb: expect.anything(),
           warnCb: expect.anything(),
           force: false,
-          local: false,
         },
       });
       expect(installProvider).toHaveBeenNthCalledWith(2, {
@@ -274,7 +271,6 @@ describe('Install CLI command', () => {
           logCb: expect.anything(),
           warnCb: expect.anything(),
           force: false,
-          local: false,
         },
       });
       expect(installProvider).toHaveBeenNthCalledWith(3, {
@@ -286,7 +282,6 @@ describe('Install CLI command', () => {
           logCb: expect.anything(),
           warnCb: expect.anything(),
           force: false,
-          local: false,
         },
       });
       expect(installProvider).toHaveBeenNthCalledWith(4, {
@@ -298,7 +293,6 @@ describe('Install CLI command', () => {
           logCb: expect.anything(),
           warnCb: expect.anything(),
           force: false,
-          local: false,
         },
       });
     }, 10000);

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -227,7 +227,6 @@ export default class Install extends Command {
           logCb: this.logCallback,
           warnCb: this.warnCallback,
           force: flags.force,
-          local: false,
         },
       });
     }

--- a/src/commands/interactive.install.integration.test.ts
+++ b/src/commands/interactive.install.integration.test.ts
@@ -109,7 +109,7 @@ describe('Interactive install CLI command', () => {
           inputs: [
             //Select providers priority
             //Sendgrid
-            { value: DOWN, timeout: 8000 },
+            { value: DOWN, timeout: 10000 },
             //Confirm slection
             { value: ENTER, timeout: 500 },
             //Mailgun
@@ -119,13 +119,13 @@ describe('Interactive install CLI command', () => {
             //Exit
             { value: UP, timeout: 6000 },
             //Confirm slection
-            { value: ENTER, timeout: 1000 },
+            { value: ENTER, timeout: 2000 },
             //Select usecase
-            { value: ENTER, timeout: 1000 },
+            { value: ENTER, timeout: 2000 },
             //Confirm provider failover
-            { value: ENTER, timeout: 1000 },
+            { value: ENTER, timeout: 2000 },
             //None
-            { value: ENTER, timeout: 1000 },
+            { value: ENTER, timeout: 2000 },
             //Sendgrid token
             { value: 'sendgridToken', timeout: 8000 },
             { value: ENTER, timeout: 500 },
@@ -272,7 +272,7 @@ describe('Interactive install CLI command', () => {
       expect(
         (parsed as { dependencies: Record<string, string> }).dependencies
       ).not.toBeUndefined();
-    }, 60000);
+    }, 70000);
 
     it('installs the profile, overrides existing super.json and updates .env', async () => {
       //Existing env

--- a/src/logic/quickstart.ts
+++ b/src/logic/quickstart.ts
@@ -265,7 +265,6 @@ export async function interactiveInstall(
         logCb: options?.logCb,
         warnCb: options?.warnCb,
         force: true,
-        local: false,
       },
     });
   }

--- a/src/logic/quickstart.ts
+++ b/src/logic/quickstart.ts
@@ -255,10 +255,8 @@ export async function interactiveInstall(
       provider,
       profileId,
       defaults: {
-        defaults: {
-          [selectedUseCase]: {
-            retryPolicy: await selectRetryPolicy(provider, selectedUseCase),
-          },
+        [selectedUseCase]: {
+          retryPolicy: await selectRetryPolicy(provider, selectedUseCase),
         },
       },
       options: {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR adds flags `localMap` and `localProvider` to `configure` command. These flags will enable us to set local map and remote provider (and vice versa) in super.json.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
