### PR TITLE
update mutate methods with new one-sdk version

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
     "@superfaceai/ast": "^0.0.25",
-    "@superfaceai/one-sdk": "^0.0.29",
+    "@superfaceai/one-sdk": "^0.0.30",
     "@superfaceai/parser": "0.0.19",
     "chalk": "^4.1.0",
     "debug": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@oclif/command": "^1.8.0",
     "@oclif/config": "^1.17.0",
     "@superfaceai/ast": "^0.0.25",
-    "@superfaceai/one-sdk": "^0.0.30",
+    "@superfaceai/one-sdk": "0.0.31",
     "@superfaceai/parser": "0.0.19",
     "chalk": "^4.1.0",
     "debug": "^4.3.1",

--- a/src/commands/check.test.ts
+++ b/src/commands/check.test.ts
@@ -77,7 +77,7 @@ describe('Check CLI command', () => {
       await expect(
         Check.run(['--profileId', profileId, '--providerName', provider])
       ).rejects.toEqual(
-        new CLIError('Unable to load super.json: test error\n')
+        new CLIError('Unable to load super.json: test error')
       );
     });
 

--- a/src/commands/check.test.ts
+++ b/src/commands/check.test.ts
@@ -71,12 +71,14 @@ describe('Check CLI command', () => {
 
     it('throws when super.json not loaded correctly', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
-      jest.spyOn(SuperJson, 'load').mockResolvedValue(
-        err(new SDKExecutionError('test error', [], []))
-      );
+      jest
+        .spyOn(SuperJson, 'load')
+        .mockResolvedValue(err(new SDKExecutionError('test error', [], [])));
       await expect(
         Check.run(['--profileId', profileId, '--providerName', provider])
-      ).rejects.toEqual(new CLIError('Unable to load super.json: test error\n'));
+      ).rejects.toEqual(
+        new CLIError('Unable to load super.json: test error\n')
+      );
     });
 
     it('throws error on invalid scan flag', async () => {

--- a/src/commands/check.test.ts
+++ b/src/commands/check.test.ts
@@ -1,5 +1,6 @@
 import { CLIError } from '@oclif/errors';
 import { err, ok, SuperJson } from '@superfaceai/one-sdk';
+import { SDKExecutionError } from '@superfaceai/one-sdk/dist/internal/errors';
 import { mocked } from 'ts-jest/utils';
 
 import { check, CheckResult, formatHuman, formatJson } from '../logic/check';
@@ -70,10 +71,12 @@ describe('Check CLI command', () => {
 
     it('throws when super.json not loaded correctly', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
-      jest.spyOn(SuperJson, 'load').mockResolvedValue(err('test error'));
+      jest.spyOn(SuperJson, 'load').mockResolvedValue(
+        err(new SDKExecutionError('test error', [], []))
+      );
       await expect(
         Check.run(['--profileId', profileId, '--providerName', provider])
-      ).rejects.toEqual(new CLIError('Unable to load super.json: test error'));
+      ).rejects.toEqual(new CLIError('Unable to load super.json: test error\n'));
     });
 
     it('throws error on invalid scan flag', async () => {

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -75,7 +75,7 @@ export default class Check extends Command {
     const superJson = loadedResult.match(
       v => v,
       err => {
-        throw userError(`Unable to load super.json: ${err}`, 1);
+        throw userError(`Unable to load super.json: ${err.formatShort()}`, 1);
       }
     );
 

--- a/src/commands/compile.test.ts
+++ b/src/commands/compile.test.ts
@@ -1,6 +1,7 @@
 import { CLIError } from '@oclif/errors';
 import { MapDocumentNode, ProfileDocumentNode } from '@superfaceai/ast';
 import { err, ok, SuperJson } from '@superfaceai/one-sdk';
+import { SDKExecutionError } from '@superfaceai/one-sdk/dist/internal/errors';
 import { mocked } from 'ts-jest/utils';
 
 import { exists, readFile } from '../common/io';
@@ -87,14 +88,16 @@ describe('Compile CLI command', () => {
       mocked(detectSuperJson).mockResolvedValue('.');
       const loadSpy = jest
         .spyOn(SuperJson, 'load')
-        .mockResolvedValue(err('test'));
+        .mockResolvedValue(
+          err(new SDKExecutionError('test', [], []))
+        );
       await expect(
         Compile.run([
           '--profileId',
           'starwars/character-information',
           '--profile',
         ])
-      ).rejects.toEqual(new CLIError('Unable to load super.json: test'));
+      ).rejects.toEqual(new CLIError('Unable to load super.json: test\n'));
       expect(loadSpy).toHaveBeenCalledTimes(1);
     });
 

--- a/src/commands/compile.test.ts
+++ b/src/commands/compile.test.ts
@@ -95,7 +95,7 @@ describe('Compile CLI command', () => {
           'starwars/character-information',
           '--profile',
         ])
-      ).rejects.toEqual(new CLIError('Unable to load super.json: test\n'));
+      ).rejects.toEqual(new CLIError('Unable to load super.json: test'));
       expect(loadSpy).toHaveBeenCalledTimes(1);
     });
 

--- a/src/commands/compile.test.ts
+++ b/src/commands/compile.test.ts
@@ -88,9 +88,7 @@ describe('Compile CLI command', () => {
       mocked(detectSuperJson).mockResolvedValue('.');
       const loadSpy = jest
         .spyOn(SuperJson, 'load')
-        .mockResolvedValue(
-          err(new SDKExecutionError('test', [], []))
-        );
+        .mockResolvedValue(err(new SDKExecutionError('test', [], [])));
       await expect(
         Compile.run([
           '--profileId',

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -68,7 +68,7 @@ export default class Compile extends Command {
     const superJson = loadedResult.match(
       v => v,
       err => {
-        throw userError(`Unable to load super.json: ${err}`, 1);
+        throw userError(`Unable to load super.json: ${err.formatShort()}`, 1);
       }
     );
     //Check flags

--- a/src/commands/configure.integration.test.ts
+++ b/src/commands/configure.integration.test.ts
@@ -362,10 +362,6 @@ describe('Configure CLI command', () => {
 
       expect(superJson.normalized.providers[simpleProvider].security).toEqual([
         {
-          id: 'apiKey',
-          apikey: '$SIMPLE_PROVIDER_API_KEY',
-        },
-        {
           id: 'swapidev',
           token: '$SIMPLE_PROVIDER_TOKEN',
         },

--- a/src/commands/configure.integration.test.ts
+++ b/src/commands/configure.integration.test.ts
@@ -369,6 +369,7 @@ describe('Configure CLI command', () => {
 
       expect(superJson.document.profiles![profileId]).toEqual({
         version: profileVersion,
+        priority: [simpleProvider],
         providers: { [simpleProvider]: {} },
       });
     }, 20000);

--- a/src/commands/create.integration.test.ts
+++ b/src/commands/create.integration.test.ts
@@ -190,13 +190,14 @@ describe('Create CLI command', () => {
       const superJson = (
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {
           [documentName]: {
             defaults: {},
             priority: [provider],
             providers: {
               [provider]: {
+                defaults: {},
                 file: `../${documentName}.${provider}.suma`,
               },
             },
@@ -259,16 +260,18 @@ describe('Create CLI command', () => {
       const superJson = (
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {
           [documentName]: {
             defaults: {},
             priority: [provider, secondProvider],
             providers: {
               [provider]: {
+                defaults: {},
                 file: `../${documentName}.${provider}.bugfix.suma`,
               },
               [secondProvider]: {
+                defaults: {},
                 file: `../${documentName}.${secondProvider}.bugfix.suma`,
               },
             },
@@ -302,7 +305,7 @@ describe('Create CLI command', () => {
       const superJson = (
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {},
         providers: {
           [provider]: {
@@ -341,7 +344,7 @@ describe('Create CLI command', () => {
       const superJson = (
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {},
         providers: {
           [provider]: {
@@ -393,13 +396,14 @@ describe('Create CLI command', () => {
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
 
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {
           [documentName]: {
             defaults: {},
             priority: [provider],
             providers: {
               [provider]: {
+                defaults: {},
                 file: `../${documentName}.${provider}.suma`,
               },
             },
@@ -454,13 +458,14 @@ describe('Create CLI command', () => {
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
 
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {
           [documentName]: {
             defaults: {},
             priority: [provider],
             providers: {
               [provider]: {
+                defaults: {},
                 file: `../${documentName}.${provider}.suma`,
               },
             },
@@ -518,7 +523,7 @@ describe('Create CLI command', () => {
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
 
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {
           [documentName]: {
             file: `../${documentName}.supr`,
@@ -526,6 +531,7 @@ describe('Create CLI command', () => {
             priority: [provider],
             providers: {
               [provider]: {
+                defaults: {},
                 file: `../${documentName}.${provider}.suma`,
               },
             },
@@ -584,7 +590,7 @@ describe('Create CLI command', () => {
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
 
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {
           [documentName]: {
             file: `../${documentName}.supr`,
@@ -592,6 +598,7 @@ describe('Create CLI command', () => {
             priority: [provider],
             providers: {
               [provider]: {
+                defaults: {},
                 file: `../${documentName}.${provider}.suma`,
               },
             },
@@ -650,7 +657,7 @@ describe('Create CLI command', () => {
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
 
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {
           [documentName]: {
             file: `../${documentName}.supr`,
@@ -658,6 +665,7 @@ describe('Create CLI command', () => {
             priority: [provider],
             providers: {
               [provider]: {
+                defaults: {},
                 file: `../${documentName}.${provider}.suma`,
               },
             },
@@ -736,7 +744,7 @@ describe('Create CLI command', () => {
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
 
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {
           [documentName]: {
             file: `../${documentName}.supr`,
@@ -744,9 +752,11 @@ describe('Create CLI command', () => {
             priority: [provider, secondProvider],
             providers: {
               [provider]: {
+                defaults: {},
                 file: `../${documentName}.${provider}.bugfix.suma`,
               },
               [secondProvider]: {
+                defaults: {},
                 file: `../${documentName}.${secondProvider}.bugfix.suma`,
               },
             },

--- a/src/commands/interactive.create.integration.test.ts
+++ b/src/commands/interactive.create.integration.test.ts
@@ -224,13 +224,14 @@ describe('Interactive create CLI command', () => {
       const superJson = (
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {
           [documentName]: {
             defaults: {},
             priority: [provider],
             providers: {
               [provider]: {
+                defaults: {},
                 file: `../${documentName}.${provider}.suma`,
               },
             },
@@ -285,13 +286,14 @@ describe('Interactive create CLI command', () => {
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
 
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {
           [documentName]: {
             defaults: {},
             priority: [provider],
             providers: {
               [provider]: {
+                defaults: {},
                 file: `../${documentName}.${provider}.suma`,
               },
             },
@@ -354,13 +356,14 @@ describe('Interactive create CLI command', () => {
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
 
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {
           [documentName]: {
             defaults: {},
             priority: [provider],
             providers: {
               [provider]: {
+                defaults: {},
                 file: `../${documentName}.${provider}.suma`,
               },
             },
@@ -423,7 +426,7 @@ describe('Interactive create CLI command', () => {
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
 
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {
           [documentName]: {
             file: `../${documentName}.supr`,
@@ -431,6 +434,7 @@ describe('Interactive create CLI command', () => {
             priority: [provider],
             providers: {
               [provider]: {
+                defaults: {},
                 file: `../${documentName}.${provider}.suma`,
               },
             },
@@ -496,7 +500,7 @@ describe('Interactive create CLI command', () => {
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
 
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {
           [documentName]: {
             file: `../${documentName}.supr`,
@@ -504,6 +508,7 @@ describe('Interactive create CLI command', () => {
             priority: [provider],
             providers: {
               [provider]: {
+                defaults: {},
                 file: `../${documentName}.${provider}.suma`,
               },
             },
@@ -568,7 +573,7 @@ describe('Interactive create CLI command', () => {
         await SuperJson.load(joinPath(tempDir, 'superface', 'super.json'))
       ).unwrap();
 
-      expect(superJson.document).toEqual({
+      expect(superJson.normalized).toEqual({
         profiles: {
           [documentName]: {
             file: `../${documentName}.supr`,
@@ -576,6 +581,7 @@ describe('Interactive create CLI command', () => {
             priority: [provider],
             providers: {
               [provider]: {
+                defaults: {},
                 file: `../${documentName}.${provider}.suma`,
               },
             },

--- a/src/commands/lint.test.ts
+++ b/src/commands/lint.test.ts
@@ -41,7 +41,7 @@ describe('lint CLI command', () => {
         .spyOn(SuperJson, 'load')
         .mockResolvedValue(err(new SDKExecutionError('test error', [], [])));
       await expect(Lint.run([])).rejects.toEqual(
-        new CLIError('Unable to load super.json: test error\n')
+        new CLIError('Unable to load super.json: test error')
       );
     });
 

--- a/src/commands/lint.test.ts
+++ b/src/commands/lint.test.ts
@@ -1,5 +1,6 @@
 import { CLIError } from '@oclif/errors';
 import { err, ok, SuperJson } from '@superfaceai/one-sdk';
+import { SDKExecutionError } from '@superfaceai/one-sdk/dist/internal/errors';
 import { mocked } from 'ts-jest/utils';
 
 import { OutputStream } from '../common/output-stream';
@@ -36,9 +37,11 @@ describe('lint CLI command', () => {
 
     it('throws when super.json not loaded correctly', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
-      jest.spyOn(SuperJson, 'load').mockResolvedValue(err('test error'));
+      jest.spyOn(SuperJson, 'load').mockResolvedValue(
+        err(new SDKExecutionError('test error', [], []))
+      );
       await expect(Lint.run([])).rejects.toEqual(
-        new CLIError('Unable to load super.json: test error')
+        new CLIError('Unable to load super.json: test error\n')
       );
     });
 

--- a/src/commands/lint.test.ts
+++ b/src/commands/lint.test.ts
@@ -37,9 +37,9 @@ describe('lint CLI command', () => {
 
     it('throws when super.json not loaded correctly', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
-      jest.spyOn(SuperJson, 'load').mockResolvedValue(
-        err(new SDKExecutionError('test error', [], []))
-      );
+      jest
+        .spyOn(SuperJson, 'load')
+        .mockResolvedValue(err(new SDKExecutionError('test error', [], [])));
       await expect(Lint.run([])).rejects.toEqual(
         new CLIError('Unable to load super.json: test error\n')
       );

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -111,7 +111,7 @@ export default class Lint extends Command {
       const superJson = loadedResult.match(
         v => v,
         err => {
-          throw userError(`Unable to load super.json: ${err}`, 1);
+          throw userError(`Unable to load super.json: ${err.formatShort()}`, 1);
         }
       );
       for (const profile of Object.values(superJson.normalized.profiles)) {

--- a/src/logic/configure.test.ts
+++ b/src/logic/configure.test.ts
@@ -127,18 +127,18 @@ describe('Configure CLI logic', () => {
     const mockSuperJson = new SuperJson();
     const mockProfileId = ProfileId.fromId('test-profile');
     it('add providers to super json', async () => {
-      const addProviderSpy = jest.spyOn(SuperJson.prototype, 'addProvider');
-      const addProfileProviderSpy = jest.spyOn(
+      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
+      const mergeProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'addProfileProvider'
+        'mergeProfileProvider'
       );
 
       expect(
         handleProviderResponse(mockSuperJson, mockProfileId, mockProviderJson)
       ).toEqual(4);
 
-      expect(addProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProviderSpy).toHaveBeenCalledWith(providerName, {
+      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProviderSpy).toHaveBeenCalledWith(providerName, {
         security: [
           { apikey: '$TEST_API_KEY', id: 'api' },
           { id: 'bearer', token: '$TEST_TOKEN' },
@@ -151,8 +151,8 @@ describe('Configure CLI logic', () => {
         ],
       });
 
-      expect(addProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProfileProviderSpy).toHaveBeenCalledWith(
+      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         providerName,
         {}
@@ -160,10 +160,10 @@ describe('Configure CLI logic', () => {
     });
 
     it('add provider with - in name to super json', async () => {
-      const addProviderSpy = jest.spyOn(SuperJson.prototype, 'addProvider');
-      const addProfileProviderSpy = jest.spyOn(
+      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
+      const mergeProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'addProfileProvider'
+        'mergeProfileProvider'
       );
 
       const customProviderJson: ProviderJson = {
@@ -204,8 +204,8 @@ describe('Configure CLI logic', () => {
         handleProviderResponse(mockSuperJson, mockProfileId, customProviderJson)
       ).toEqual(4);
 
-      expect(addProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProviderSpy).toHaveBeenCalledWith('provider-test', {
+      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProviderSpy).toHaveBeenCalledWith('provider-test', {
         security: [
           { apikey: '$PROVIDER_TEST_API_KEY', id: 'api' },
           { id: 'bearer', token: '$PROVIDER_TEST_TOKEN' },
@@ -218,8 +218,8 @@ describe('Configure CLI logic', () => {
         ],
       });
 
-      expect(addProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProfileProviderSpy).toHaveBeenCalledWith(
+      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         'provider-test',
         {}
@@ -245,10 +245,10 @@ describe('Configure CLI logic', () => {
         ],
         defaultService: 'swapidev',
       };
-      const addProviderSpy = jest.spyOn(SuperJson.prototype, 'addProvider');
-      const addProfileProviderSpy = jest.spyOn(
+      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
+      const mergeProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'addProfileProvider'
+        'mergeProfileProvider'
       );
 
       expect(
@@ -259,13 +259,13 @@ describe('Configure CLI logic', () => {
         )
       ).toEqual(0);
 
-      expect(addProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProviderSpy).toHaveBeenCalledWith(providerName, {
+      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProviderSpy).toHaveBeenCalledWith(providerName, {
         security: [],
       });
 
-      expect(addProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProfileProviderSpy).toHaveBeenCalledWith(
+      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         providerName,
         {}
@@ -324,10 +324,10 @@ describe('Configure CLI logic', () => {
 
       mocked(fetchProviderInfo).mockResolvedValue(mockProviderJson);
 
-      const addProviderSpy = jest.spyOn(SuperJson.prototype, 'addProvider');
-      const addProfileProviderSpy = jest.spyOn(
+      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
+      const mergeProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'addProfileProvider'
+        'mergeProfileProvider'
       );
 
       const writeOnceSpy = jest
@@ -350,15 +350,15 @@ describe('Configure CLI logic', () => {
 
       expect(fetchProviderInfo).toHaveBeenCalledTimes(1);
 
-      expect(addProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProfileProviderSpy).toHaveBeenCalledWith(
+      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         providerName,
         { defaults: { testUseCase: { retryPolicy: OnFail.CIRCUIT_BREAKER } } }
       );
 
-      expect(addProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProviderSpy).toHaveBeenCalledWith(providerName, {
+      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProviderSpy).toHaveBeenCalledWith(providerName, {
         security: [
           { apikey: '$TEST_API_KEY', id: 'api' },
           { id: 'bearer', token: '$TEST_TOKEN' },
@@ -393,10 +393,10 @@ describe('Configure CLI logic', () => {
         .mockResolvedValue(ok(mockSuperJson));
       mocked(fetchProviderInfo).mockResolvedValue(mockProviderJson);
 
-      const addProviderSpy = jest.spyOn(SuperJson.prototype, 'addProvider');
-      const addProfileProviderSpy = jest.spyOn(
+      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
+      const mergeProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'addProfileProvider'
+        'mergeProfileProvider'
       );
 
       const writeOnceSpy = jest
@@ -420,15 +420,15 @@ describe('Configure CLI logic', () => {
 
       expect(fetchProviderInfo).toHaveBeenCalledTimes(1);
 
-      expect(addProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProfileProviderSpy).toHaveBeenCalledWith(
+      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         providerName,
         { defaults: { testUseCase: { retryPolicy: OnFail.CIRCUIT_BREAKER } } }
       );
 
-      expect(addProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProviderSpy).toHaveBeenCalledWith(providerName, {
+      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProviderSpy).toHaveBeenCalledWith(providerName, {
         security: [
           { apikey: '$TEST_API_KEY', id: 'api' },
           { id: 'bearer', token: '$TEST_TOKEN' },
@@ -466,10 +466,10 @@ describe('Configure CLI logic', () => {
         .spyOn(SuperJson, 'load')
         .mockResolvedValue(ok(mockSuperJson));
 
-      const addProviderSpy = jest.spyOn(SuperJson.prototype, 'addProvider');
-      const addProfileProviderSpy = jest.spyOn(
+      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
+      const mergeProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'addProfileProvider'
+        'mergeProfileProvider'
       );
 
       const writeOnceSpy = jest
@@ -495,15 +495,15 @@ describe('Configure CLI logic', () => {
 
       expect(fetchProviderInfo).toHaveBeenCalledTimes(1);
 
-      expect(addProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProfileProviderSpy).toHaveBeenCalledWith(
+      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         providerName,
         {}
       );
 
-      expect(addProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProviderSpy).toHaveBeenCalledWith(providerName, {
+      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProviderSpy).toHaveBeenCalledWith(providerName, {
         security: [
           { apikey: '$TEST_API_KEY', id: 'api' },
           { id: 'bearer', token: '$TEST_TOKEN' },
@@ -537,10 +537,10 @@ describe('Configure CLI logic', () => {
         .spyOn(SuperJson, 'load')
         .mockResolvedValue(ok(mockSuperJson));
 
-      const addProviderSpy = jest.spyOn(SuperJson.prototype, 'addProvider');
-      const addProfileProviderSpy = jest.spyOn(
+      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
+      const mergeProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'addProfileProvider'
+        'mergeProfileProvider'
       );
 
       const writeOnceSpy = jest
@@ -566,15 +566,15 @@ describe('Configure CLI logic', () => {
 
       expect(fetchProviderInfo).not.toHaveBeenCalled();
 
-      expect(addProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProfileProviderSpy).toHaveBeenCalledWith(
+      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         providerName,
         {}
       );
 
-      expect(addProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProviderSpy).toHaveBeenCalledWith(providerName, {
+      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProviderSpy).toHaveBeenCalledWith(providerName, {
         security: [
           { apikey: '$TEST_API_KEY', id: 'api' },
           { id: 'bearer', token: '$TEST_TOKEN' },
@@ -608,10 +608,10 @@ describe('Configure CLI logic', () => {
         .spyOn(SuperJson, 'load')
         .mockResolvedValue(ok(mockSuperJson));
 
-      const addProviderSpy = jest.spyOn(SuperJson.prototype, 'addProvider');
-      const addProfileProviderSpy = jest.spyOn(
+      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
+      const mergeProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'addProfileProvider'
+        'mergeProfileProvider'
       );
 
       const writeOnceSpy = jest
@@ -638,15 +638,15 @@ describe('Configure CLI logic', () => {
 
       expect(fetchProviderInfo).toHaveBeenCalledTimes(1);
 
-      expect(addProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProfileProviderSpy).toHaveBeenCalledWith(
+      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         providerName,
         {}
       );
 
-      expect(addProviderSpy).toHaveBeenCalledTimes(1);
-      expect(addProviderSpy).toHaveBeenCalledWith(providerName, {
+      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
+      expect(mergeProviderSpy).toHaveBeenCalledWith(providerName, {
         security: [
           { apikey: '$TEST_API_KEY', id: 'api' },
           { id: 'bearer', token: '$TEST_TOKEN' },
@@ -753,10 +753,10 @@ describe('Configure CLI logic', () => {
 
       mocked(fetchProviderInfo).mockResolvedValue(mockProviderJson);
 
-      const addProviderSpy = jest.spyOn(SuperJson.prototype, 'addProvider');
-      const addProfileProviderSpy = jest.spyOn(
+      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
+      const mergeProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'addProfileProvider'
+        'mergeProfileProvider'
       );
 
       const writeOnceSpy = jest
@@ -776,8 +776,8 @@ describe('Configure CLI logic', () => {
 
       expect(fetchProviderInfo).toHaveBeenCalledTimes(1);
 
-      expect(addProfileProviderSpy).not.toHaveBeenCalled();
-      expect(addProviderSpy).not.toHaveBeenCalled();
+      expect(mergeProfileProviderSpy).not.toHaveBeenCalled();
+      expect(mergeProviderSpy).not.toHaveBeenCalled();
       expect(writeOnceSpy).not.toHaveBeenCalled();
     });
   });

--- a/src/logic/configure.test.ts
+++ b/src/logic/configure.test.ts
@@ -127,18 +127,18 @@ describe('Configure CLI logic', () => {
     const mockSuperJson = new SuperJson();
     const mockProfileId = ProfileId.fromId('test-profile');
     it('add providers to super json', async () => {
-      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
-      const mergeProfileProviderSpy = jest.spyOn(
+      const setProviderSpy = jest.spyOn(SuperJson.prototype, 'setProvider');
+      const setProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'mergeProfileProvider'
+        'setProfileProvider'
       );
 
       expect(
         handleProviderResponse(mockSuperJson, mockProfileId, mockProviderJson)
       ).toEqual(4);
 
-      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProviderSpy).toHaveBeenCalledWith(providerName, {
+      expect(setProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProviderSpy).toHaveBeenCalledWith(providerName, {
         security: [
           { apikey: '$TEST_API_KEY', id: 'api' },
           { id: 'bearer', token: '$TEST_TOKEN' },
@@ -151,8 +151,8 @@ describe('Configure CLI logic', () => {
         ],
       });
 
-      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
+      expect(setProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         providerName,
         {}
@@ -160,10 +160,10 @@ describe('Configure CLI logic', () => {
     });
 
     it('add provider with - in name to super json', async () => {
-      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
-      const mergeProfileProviderSpy = jest.spyOn(
+      const setProviderSpy = jest.spyOn(SuperJson.prototype, 'setProvider');
+      const setProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'mergeProfileProvider'
+        'setProfileProvider'
       );
 
       const customProviderJson: ProviderJson = {
@@ -204,8 +204,8 @@ describe('Configure CLI logic', () => {
         handleProviderResponse(mockSuperJson, mockProfileId, customProviderJson)
       ).toEqual(4);
 
-      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProviderSpy).toHaveBeenCalledWith('provider-test', {
+      expect(setProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProviderSpy).toHaveBeenCalledWith('provider-test', {
         security: [
           { apikey: '$PROVIDER_TEST_API_KEY', id: 'api' },
           { id: 'bearer', token: '$PROVIDER_TEST_TOKEN' },
@@ -218,8 +218,8 @@ describe('Configure CLI logic', () => {
         ],
       });
 
-      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
+      expect(setProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         'provider-test',
         {}
@@ -245,10 +245,10 @@ describe('Configure CLI logic', () => {
         ],
         defaultService: 'swapidev',
       };
-      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
-      const mergeProfileProviderSpy = jest.spyOn(
+      const setProviderSpy = jest.spyOn(SuperJson.prototype, 'setProvider');
+      const setProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'mergeProfileProvider'
+        'setProfileProvider'
       );
 
       expect(
@@ -259,13 +259,13 @@ describe('Configure CLI logic', () => {
         )
       ).toEqual(0);
 
-      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProviderSpy).toHaveBeenCalledWith(providerName, {
+      expect(setProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProviderSpy).toHaveBeenCalledWith(providerName, {
         security: [],
       });
 
-      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
+      expect(setProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         providerName,
         {}
@@ -324,10 +324,10 @@ describe('Configure CLI logic', () => {
 
       mocked(fetchProviderInfo).mockResolvedValue(mockProviderJson);
 
-      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
-      const mergeProfileProviderSpy = jest.spyOn(
+      const setProviderSpy = jest.spyOn(SuperJson.prototype, 'setProvider');
+      const setProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'mergeProfileProvider'
+        'setProfileProvider'
       );
 
       const writeOnceSpy = jest
@@ -350,15 +350,15 @@ describe('Configure CLI logic', () => {
 
       expect(fetchProviderInfo).toHaveBeenCalledTimes(1);
 
-      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
+      expect(setProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         providerName,
         { defaults: { testUseCase: { retryPolicy: OnFail.CIRCUIT_BREAKER } } }
       );
 
-      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProviderSpy).toHaveBeenCalledWith(providerName, {
+      expect(setProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProviderSpy).toHaveBeenCalledWith(providerName, {
         security: [
           { apikey: '$TEST_API_KEY', id: 'api' },
           { id: 'bearer', token: '$TEST_TOKEN' },
@@ -393,10 +393,10 @@ describe('Configure CLI logic', () => {
         .mockResolvedValue(ok(mockSuperJson));
       mocked(fetchProviderInfo).mockResolvedValue(mockProviderJson);
 
-      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
-      const mergeProfileProviderSpy = jest.spyOn(
+      const setProviderSpy = jest.spyOn(SuperJson.prototype, 'setProvider');
+      const setProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'mergeProfileProvider'
+        'setProfileProvider'
       );
 
       const writeOnceSpy = jest
@@ -420,15 +420,15 @@ describe('Configure CLI logic', () => {
 
       expect(fetchProviderInfo).toHaveBeenCalledTimes(1);
 
-      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
+      expect(setProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         providerName,
         { defaults: { testUseCase: { retryPolicy: OnFail.CIRCUIT_BREAKER } } }
       );
 
-      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProviderSpy).toHaveBeenCalledWith(providerName, {
+      expect(setProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProviderSpy).toHaveBeenCalledWith(providerName, {
         security: [
           { apikey: '$TEST_API_KEY', id: 'api' },
           { id: 'bearer', token: '$TEST_TOKEN' },
@@ -466,10 +466,10 @@ describe('Configure CLI logic', () => {
         .spyOn(SuperJson, 'load')
         .mockResolvedValue(ok(mockSuperJson));
 
-      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
-      const mergeProfileProviderSpy = jest.spyOn(
+      const setProviderSpy = jest.spyOn(SuperJson.prototype, 'setProvider');
+      const setProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'mergeProfileProvider'
+        'setProfileProvider'
       );
 
       const writeOnceSpy = jest
@@ -495,15 +495,15 @@ describe('Configure CLI logic', () => {
 
       expect(fetchProviderInfo).toHaveBeenCalledTimes(1);
 
-      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
+      expect(setProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         providerName,
         {}
       );
 
-      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProviderSpy).toHaveBeenCalledWith(providerName, {
+      expect(setProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProviderSpy).toHaveBeenCalledWith(providerName, {
         security: [
           { apikey: '$TEST_API_KEY', id: 'api' },
           { id: 'bearer', token: '$TEST_TOKEN' },
@@ -537,10 +537,10 @@ describe('Configure CLI logic', () => {
         .spyOn(SuperJson, 'load')
         .mockResolvedValue(ok(mockSuperJson));
 
-      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
-      const mergeProfileProviderSpy = jest.spyOn(
+      const setProviderSpy = jest.spyOn(SuperJson.prototype, 'setProvider');
+      const setProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'mergeProfileProvider'
+        'setProfileProvider'
       );
 
       const writeOnceSpy = jest
@@ -566,15 +566,15 @@ describe('Configure CLI logic', () => {
 
       expect(fetchProviderInfo).not.toHaveBeenCalled();
 
-      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
+      expect(setProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         providerName,
         {}
       );
 
-      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProviderSpy).toHaveBeenCalledWith(providerName, {
+      expect(setProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProviderSpy).toHaveBeenCalledWith(providerName, {
         security: [
           { apikey: '$TEST_API_KEY', id: 'api' },
           { id: 'bearer', token: '$TEST_TOKEN' },
@@ -608,10 +608,10 @@ describe('Configure CLI logic', () => {
         .spyOn(SuperJson, 'load')
         .mockResolvedValue(ok(mockSuperJson));
 
-      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
-      const mergeProfileProviderSpy = jest.spyOn(
+      const setProviderSpy = jest.spyOn(SuperJson.prototype, 'setProvider');
+      const setProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'mergeProfileProvider'
+        'setProfileProvider'
       );
 
       const writeOnceSpy = jest
@@ -638,15 +638,15 @@ describe('Configure CLI logic', () => {
 
       expect(fetchProviderInfo).toHaveBeenCalledTimes(1);
 
-      expect(mergeProfileProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProfileProviderSpy).toHaveBeenCalledWith(
+      expect(setProfileProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProfileProviderSpy).toHaveBeenCalledWith(
         mockProfileId.id,
         providerName,
         {}
       );
 
-      expect(mergeProviderSpy).toHaveBeenCalledTimes(1);
-      expect(mergeProviderSpy).toHaveBeenCalledWith(providerName, {
+      expect(setProviderSpy).toHaveBeenCalledTimes(1);
+      expect(setProviderSpy).toHaveBeenCalledWith(providerName, {
         security: [
           { apikey: '$TEST_API_KEY', id: 'api' },
           { id: 'bearer', token: '$TEST_TOKEN' },
@@ -753,10 +753,10 @@ describe('Configure CLI logic', () => {
 
       mocked(fetchProviderInfo).mockResolvedValue(mockProviderJson);
 
-      const mergeProviderSpy = jest.spyOn(SuperJson.prototype, 'mergeProvider');
-      const mergeProfileProviderSpy = jest.spyOn(
+      const setProviderSpy = jest.spyOn(SuperJson.prototype, 'setProvider');
+      const setProfileProviderSpy = jest.spyOn(
         SuperJson.prototype,
-        'mergeProfileProvider'
+        'setProfileProvider'
       );
 
       const writeOnceSpy = jest
@@ -776,8 +776,8 @@ describe('Configure CLI logic', () => {
 
       expect(fetchProviderInfo).toHaveBeenCalledTimes(1);
 
-      expect(mergeProfileProviderSpy).not.toHaveBeenCalled();
-      expect(mergeProviderSpy).not.toHaveBeenCalled();
+      expect(setProfileProviderSpy).not.toHaveBeenCalled();
+      expect(setProviderSpy).not.toHaveBeenCalled();
       expect(writeOnceSpy).not.toHaveBeenCalled();
     });
   });

--- a/src/logic/configure.test.ts
+++ b/src/logic/configure.test.ts
@@ -722,7 +722,9 @@ describe('Configure CLI logic', () => {
           profileId: mockProfileId,
         })
       ).rejects.toEqual(
-        new CLIError(`❌ profile ${mockProfileId.id} not found in "some/path/super.json".`)
+        new CLIError(
+          `❌ profile ${mockProfileId.id} not found in "some/path/super.json".`
+        )
       );
 
       expect(fetchProviderInfo).not.toHaveBeenCalled();

--- a/src/logic/configure.ts
+++ b/src/logic/configure.ts
@@ -113,13 +113,17 @@ export function handleProviderResponse(
       }
     }
   }
+
   // update super.json
-  superJson.addProvider(response.name, {
+  // superJson.setProvider(response.name, {
+  superJson.mergeProvider(response.name, {
     security,
     file: options?.localProvider
       ? superJson.relativePath(options.localProvider)
-      : undefined,
+      : undefined
   });
+
+  superJson.mergeProvider
 
   //constructProfileProviderSettings returns Record<string, ProfileProviderEntry>
   let settings = defaults
@@ -136,7 +140,8 @@ export function handleProviderResponse(
       };
     }
   }
-  superJson.addProfileProvider(profileId.id, response.name, settings);
+  // superJson.setProfileProvider(profileId.id, response.name, settings);
+  superJson.mergeProfileProvider(profileId.id, response.name, settings);
 
   return security.length;
 }
@@ -187,7 +192,7 @@ export async function installProvider(parameters: {
   const superJson = loadedResult.match(
     v => v,
     err => {
-      parameters.options?.warnCb?.(err);
+      parameters.options?.warnCb?.(err.formatLong());
 
       return new SuperJson({});
     }

--- a/src/logic/configure.ts
+++ b/src/logic/configure.ts
@@ -83,7 +83,7 @@ export function handleProviderResponse(
           response.securitySchemes.length
         } security schemes`
       );
-      //Char - is not allowed in env variables so replace it with _
+      // Char "-" is not allowed in env variables so replace it with "_"
       const envProviderName = response.name.replace('-', '_').toUpperCase();
       if (isApiKeySecurityScheme(scheme)) {
         security.push({
@@ -115,15 +115,12 @@ export function handleProviderResponse(
   }
 
   // update super.json
-  // superJson.setProvider(response.name, {
-  superJson.mergeProvider(response.name, {
+  superJson.setProvider(response.name, {
     security,
     file: options?.localProvider
       ? superJson.relativePath(options.localProvider)
       : undefined
   });
-
-  superJson.mergeProvider
 
   //constructProfileProviderSettings returns Record<string, ProfileProviderEntry>
   let settings = defaults
@@ -140,8 +137,7 @@ export function handleProviderResponse(
       };
     }
   }
-  // superJson.setProfileProvider(profileId.id, response.name, settings);
-  superJson.mergeProfileProvider(profileId.id, response.name, settings);
+  superJson.setProfileProvider(profileId.id, response.name, settings);
 
   return security.length;
 }

--- a/src/logic/configure.ts
+++ b/src/logic/configure.ts
@@ -119,7 +119,7 @@ export function handleProviderResponse(
     security,
     file: options?.localProvider
       ? superJson.relativePath(options.localProvider)
-      : undefined
+      : undefined,
   });
 
   //constructProfileProviderSettings returns Record<string, ProfileProviderEntry>
@@ -278,40 +278,35 @@ export async function installProvider(parameters: {
 
 /**
  * Reconfigure provider from local to remote or from remote to local.
-*/
+ */
 export async function reconfigureProvider(
   superJson: SuperJson,
   providerName: string,
-  target: { kind: 'local', file: string } | { kind: 'remote' },
+  target: { kind: 'local'; file: string } | { kind: 'remote' },
   _options?: {
-    logCb?: LogCallback
-    warnCb?: LogCallback
+    logCb?: LogCallback;
+    warnCb?: LogCallback;
   }
 ): Promise<void> {
   // TODO: Possibly do checks whether the remote file exists?
-  superJson.swapProviderVariant(
-    providerName,
-    target
-  )
+  superJson.swapProviderVariant(providerName, target);
 }
 
 /**
  * Reconfigure profile provider from local to remote or from remote to local.
-*/
+ */
 export async function reconfigureProfileProvider(
   superJson: SuperJson,
   profileId: ProfileId,
   providerName: string,
-  target: { kind: 'local', file: string } | { kind: 'remote', mapVariant?: string, mapRevision?: string },
+  target:
+    | { kind: 'local'; file: string }
+    | { kind: 'remote'; mapVariant?: string; mapRevision?: string },
   _options?: {
-    logCb?: LogCallback
-    warnCb?: LogCallback
+    logCb?: LogCallback;
+    warnCb?: LogCallback;
   }
 ): Promise<void> {
   // TODO: Possibly do checks whether the remote file exists?
-  superJson.swapProfileProviderVariant(
-    profileId.id,
-    providerName,
-    target
-  )
+  superJson.swapProfileProviderVariant(profileId.id, providerName, target);
 }

--- a/src/logic/configure.ts
+++ b/src/logic/configure.ts
@@ -275,3 +275,43 @@ export async function installProvider(parameters: {
     parameters.options?.logCb?.(`No security schemes found to configure.`);
   }
 }
+
+/**
+ * Reconfigure provider from local to remote or from remote to local.
+*/
+export async function reconfigureProvider(
+  superJson: SuperJson,
+  providerName: string,
+  target: { kind: 'local', file: string } | { kind: 'remote' },
+  _options?: {
+    logCb?: LogCallback
+    warnCb?: LogCallback
+  }
+): Promise<void> {
+  // TODO: Possibly do checks whether the remote file exists?
+  superJson.swapProviderVariant(
+    providerName,
+    target
+  )
+}
+
+/**
+ * Reconfigure profile provider from local to remote or from remote to local.
+*/
+export async function reconfigureProfileProvider(
+  superJson: SuperJson,
+  profileId: ProfileId,
+  providerName: string,
+  target: { kind: 'local', file: string } | { kind: 'remote', mapVariant?: string, mapRevision?: string },
+  _options?: {
+    logCb?: LogCallback
+    warnCb?: LogCallback
+  }
+): Promise<void> {
+  // TODO: Possibly do checks whether the remote file exists?
+  superJson.swapProfileProviderVariant(
+    profileId.id,
+    providerName,
+    target
+  )
+}

--- a/src/logic/create.test.ts
+++ b/src/logic/create.test.ts
@@ -363,9 +363,7 @@ describe('Create logic', () => {
     it('creates profile correctly - uses new super json instance', async () => {
       const loadSpy = jest
         .spyOn(SuperJson, 'load')
-        .mockResolvedValue(
-          err(new SDKExecutionError('mock err', [], []))
-        );
+        .mockResolvedValue(err(new SDKExecutionError('mock err', [], [])));
       const writeIfAbsentSpy = jest
         .spyOn(OutputStream, 'writeIfAbsent')
         .mockResolvedValue(true);

--- a/src/logic/create.test.ts
+++ b/src/logic/create.test.ts
@@ -1,5 +1,6 @@
 import { CLIError } from '@oclif/errors';
 import { err, ok, SuperJson } from '@superfaceai/one-sdk';
+import { SDKExecutionError } from '@superfaceai/one-sdk/dist/internal/errors';
 
 import { OutputStream } from '../common/output-stream';
 import { empty as emptyMap } from '../templates/map';
@@ -362,7 +363,9 @@ describe('Create logic', () => {
     it('creates profile correctly - uses new super json instance', async () => {
       const loadSpy = jest
         .spyOn(SuperJson, 'load')
-        .mockResolvedValue(err('mock err'));
+        .mockResolvedValue(
+          err(new SDKExecutionError('mock err', [], []))
+        );
       const writeIfAbsentSpy = jest
         .spyOn(OutputStream, 'writeIfAbsent')
         .mockResolvedValue(true);

--- a/src/logic/create.ts
+++ b/src/logic/create.ts
@@ -51,7 +51,7 @@ export async function createProfile(
       `-> Created ${filePath} (name = "${profileName}", version = "${version}")`
     );
     if (superJson) {
-      superJson.addProfile(profileName, {
+      superJson.mergeProfile(profileName, {
         file: relativePath(dirname(superJson.path), filePath),
       });
     }
@@ -103,7 +103,7 @@ export async function createMap(
       `-> Created ${filePath} (profile = "${profileName}@${version}", provider = "${id.provider}")`
     );
     if (superJson) {
-      superJson.addProfileProvider(profileName, id.provider, {
+      superJson.mergeProfileProvider(profileName, id.provider, {
         file: relativePath(dirname(superJson.path), filePath),
       });
     }
@@ -131,7 +131,7 @@ export async function createProviderJson(
   if (created) {
     options?.logCb?.(`-> Created ${name}.provider.json`);
     if (superJson) {
-      superJson.addProvider(name, {
+      superJson.mergeProvider(name, {
         file: relativePath(dirname(superJson.path), filePath),
       });
     }
@@ -169,7 +169,7 @@ export async function create(
     superJson = loadedResult.match(
       v => v,
       err => {
-        options?.warnCb?.(err);
+        options?.warnCb?.(err.formatLong());
 
         return new SuperJson({});
       }

--- a/src/logic/install.test.ts
+++ b/src/logic/install.test.ts
@@ -550,7 +550,7 @@ describe('Install CLI logic', () => {
       const profileId = 'starwars/character-information';
       const stubSuperJson = new SuperJson({});
 
-      stubSuperJson.addProfile(profileId, { version: '1.0.1' });
+      stubSuperJson.mergeProfile(profileId, { version: '1.0.1' });
       await expect(getExistingProfileIds(stubSuperJson)).resolves.toEqual([
         {
           profileId: ProfileId.fromId(profileId),
@@ -573,7 +573,7 @@ describe('Install CLI logic', () => {
 
       const profileId = 'starwars/character-information';
       const stubSuperJson = new SuperJson({});
-      stubSuperJson.addProfile(profileId, {
+      stubSuperJson.mergeProfile(profileId, {
         file: 'fixtures/install/playground/character-information.supr',
       });
       await expect(getExistingProfileIds(stubSuperJson)).resolves.toEqual([
@@ -704,8 +704,8 @@ describe('Install CLI logic', () => {
         const mockLoad = jest.fn();
 
         const stubSuperJson = new SuperJson({});
-        stubSuperJson.addProfile('starwars/first', { version: '1.0.0' });
-        stubSuperJson.addProfile('starwars/second', { version: '2.0.0' });
+        stubSuperJson.mergeProfile('starwars/first', { version: '1.0.0' });
+        stubSuperJson.mergeProfile('starwars/second', { version: '2.0.0' });
 
         mockLoad.mockResolvedValue(ok(stubSuperJson));
         SuperJson.load = mockLoad;

--- a/src/logic/install.ts
+++ b/src/logic/install.ts
@@ -194,11 +194,11 @@ export async function resolveInstallationRequests(
   for (const entry of phase3) {
     installDebug('Install phase 4:', entry);
     if (entry.kind === 'local') {
-      superJson.addProfile(entry.profileId.id, {
+      superJson.mergeProfile(entry.profileId.id, {
         file: superJson.relativePath(entry.path),
       });
     } else {
-      superJson.addProfile(entry.profileId.id, {
+      superJson.mergeProfile(entry.profileId.id, {
         version: entry.info.profile_version,
       });
     }
@@ -559,7 +559,7 @@ export async function installProfiles(parameters: {
   const superJson = loadedResult.match(
     v => v,
     err => {
-      parameters.options?.warnCb?.(err);
+      parameters.options?.warnCb?.(err.formatLong());
 
       return new SuperJson({});
     }

--- a/src/logic/quickstart.ts
+++ b/src/logic/quickstart.ts
@@ -243,7 +243,7 @@ export async function interactiveInstall(
       )
     ) {
       //Add provider failover
-      superJson.addProfileDefaults(profileId.id, {
+      superJson.mergeProfileDefaults(profileId.id, {
         [selectedUseCase]: { providerFailover: true },
       });
       await OutputStream.writeOnce(superJson.path, superJson.stringified, {

--- a/yarn.lock
+++ b/yarn.lock
@@ -882,10 +882,10 @@
   resolved "https://registry.yarnpkg.com/@superfaceai/ast/-/ast-0.0.25.tgz#f8bb0d6d7e74932600c8326cd6c445540e42a952"
   integrity sha512-5zSC2X+gqPiEvjKHcGLEjUsKJ4RNyXM8AmKhNSNw3CoahmSwftCFIL4YRHzeI+nnvh82qd5RbxNFeRt0Tn4adA==
 
-"@superfaceai/one-sdk@^0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-0.0.30.tgz#7b26896945e78c30c7d874d6bce1b3a953b5a71b"
-  integrity sha512-z5MVVd5YM6QtbrW94agjAe1pz/26ZRdtx3vuJXjLsvAqcOzEuGBEfZ4fS3kvxNF/VCsDbr7lYvlrq/z3fp10+g==
+"@superfaceai/one-sdk@0.0.31":
+  version "0.0.31"
+  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-0.0.31.tgz#132cf5cc0b63030d91ef924a061dc7cc7ba692c5"
+  integrity sha512-Dzuep+RDIQOKKhOUhu0O6aYcWXszAbtakwROtpDIEP3vh9sgY6a8b8CAzXRHyUO9zu5P660xEPz04GKJNKlr2g==
   dependencies:
     "@superfaceai/ast" "0.0.23"
     abort-controller "^3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -882,14 +882,12 @@
   resolved "https://registry.yarnpkg.com/@superfaceai/ast/-/ast-0.0.25.tgz#f8bb0d6d7e74932600c8326cd6c445540e42a952"
   integrity sha512-5zSC2X+gqPiEvjKHcGLEjUsKJ4RNyXM8AmKhNSNw3CoahmSwftCFIL4YRHzeI+nnvh82qd5RbxNFeRt0Tn4adA==
 
-"@superfaceai/one-sdk@^0.0.29":
-  version "0.0.29"
-  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-0.0.29.tgz#79bf1a3f9260c05504eb55575cd1e083808b6eaa"
-  integrity sha512-jau52Bkr10+1Bk9YyODJ0t75r8fSFqwRu4vIxaKEd6+2fV2+umCvYqqe4H1GnomfwP76fRy3SZaTAc17SFjVjg==
+"@superfaceai/one-sdk@^0.0.30":
+  version "0.0.30"
+  resolved "https://registry.yarnpkg.com/@superfaceai/one-sdk/-/one-sdk-0.0.30.tgz#7b26896945e78c30c7d874d6bce1b3a953b5a71b"
+  integrity sha512-z5MVVd5YM6QtbrW94agjAe1pz/26ZRdtx3vuJXjLsvAqcOzEuGBEfZ4fS3kvxNF/VCsDbr7lYvlrq/z3fp10+g==
   dependencies:
     "@superfaceai/ast" "0.0.23"
-    "@typescript-eslint/eslint-plugin" "^4.27.0"
-    "@typescript-eslint/parser" "^4.27.0"
     abort-controller "^3.0.0"
     cross-fetch "^3.0.5"
     debug "^4.3.1"
@@ -1174,19 +1172,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@typescript-eslint/eslint-plugin@^4.27.0":
-  version "4.28.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.2.tgz#7a8320f00141666813d0ae43b49ee8244f7cf92a"
-  integrity sha512-PGqpLLzHSxq956rzNGasO3GsAPf2lY9lDUBXhS++SKonglUmJypaUtcKzRtUte8CV7nruwnDxtLUKpVxs0wQBw==
-  dependencies:
-    "@typescript-eslint/experimental-utils" "4.28.2"
-    "@typescript-eslint/scope-manager" "4.28.2"
-    debug "^4.3.1"
-    functional-red-black-tree "^1.0.1"
-    regexpp "^3.1.0"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
-
 "@typescript-eslint/eslint-plugin@^4.28.4":
   version "4.28.4"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.28.4.tgz#e73c8cabbf3f08dee0e1bda65ed4e622ae8f8921"
@@ -1199,18 +1184,6 @@
     regexpp "^3.1.0"
     semver "^7.3.5"
     tsutils "^3.21.0"
-
-"@typescript-eslint/experimental-utils@4.28.2":
-  version "4.28.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-4.28.2.tgz#4ebdec06a10888e9326e1d51d81ad52a361bd0b0"
-  integrity sha512-MwHPsL6qo98RC55IoWWP8/opTykjTp4JzfPu1VfO2Z0MshNP0UZ1GEV5rYSSnZSUI8VD7iHvtIPVGW5Nfh7klQ==
-  dependencies:
-    "@types/json-schema" "^7.0.7"
-    "@typescript-eslint/scope-manager" "4.28.2"
-    "@typescript-eslint/types" "4.28.2"
-    "@typescript-eslint/typescript-estree" "4.28.2"
-    eslint-scope "^5.1.1"
-    eslint-utils "^3.0.0"
 
 "@typescript-eslint/experimental-utils@4.28.4":
   version "4.28.4"
@@ -1236,16 +1209,6 @@
     eslint-scope "^5.0.0"
     eslint-utils "^2.0.0"
 
-"@typescript-eslint/parser@^4.27.0":
-  version "4.28.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.28.2.tgz#6aff11bf4b91eb67ca7517962eede951e9e2a15d"
-  integrity sha512-Q0gSCN51eikAgFGY+gnd5p9bhhCUAl0ERMiDKrTzpSoMYRubdB8MJrTTR/BBii8z+iFwz8oihxd0RAdP4l8w8w==
-  dependencies:
-    "@typescript-eslint/scope-manager" "4.28.2"
-    "@typescript-eslint/types" "4.28.2"
-    "@typescript-eslint/typescript-estree" "4.28.2"
-    debug "^4.3.1"
-
 "@typescript-eslint/parser@^4.28.4":
   version "4.28.4"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-4.28.4.tgz#bc462dc2779afeefdcf49082516afdc3e7b96fab"
@@ -1264,14 +1227,6 @@
     "@typescript-eslint/types" "4.16.1"
     "@typescript-eslint/visitor-keys" "4.16.1"
 
-"@typescript-eslint/scope-manager@4.28.2":
-  version "4.28.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.2.tgz#451dce90303a3ce283750111495d34c9c204e510"
-  integrity sha512-MqbypNjIkJFEFuOwPWNDjq0nqXAKZvDNNs9yNseoGBB1wYfz1G0WHC2AVOy4XD7di3KCcW3+nhZyN6zruqmp2A==
-  dependencies:
-    "@typescript-eslint/types" "4.28.2"
-    "@typescript-eslint/visitor-keys" "4.28.2"
-
 "@typescript-eslint/scope-manager@4.28.4":
   version "4.28.4"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.28.4.tgz#bdbce9b6a644e34f767bd68bc17bb14353b9fe7f"
@@ -1284,11 +1239,6 @@
   version "4.16.1"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.16.1.tgz#5ba2d3e38b1a67420d2487519e193163054d9c15"
   integrity sha512-nnKqBwMgRlhzmJQF8tnFDZWfunXmJyuXj55xc8Kbfup4PbkzdoDXZvzN8//EiKR27J6vUSU8j4t37yUuYPiLqA==
-
-"@typescript-eslint/types@4.28.2":
-  version "4.28.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.28.2.tgz#e6b9e234e0e9a66c4d25bab881661e91478223b5"
-  integrity sha512-Gr15fuQVd93uD9zzxbApz3wf7ua3yk4ZujABZlZhaxxKY8ojo448u7XTm/+ETpy0V0dlMtj6t4VdDvdc0JmUhA==
 
 "@typescript-eslint/types@4.28.4":
   version "4.28.4"
@@ -1307,19 +1257,6 @@
     is-glob "^4.0.1"
     semver "^7.3.2"
     tsutils "^3.17.1"
-
-"@typescript-eslint/typescript-estree@4.28.2":
-  version "4.28.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.28.2.tgz#680129b2a285289a15e7c6108c84739adf3a798c"
-  integrity sha512-86lLstLvK6QjNZjMoYUBMMsULFw0hPHJlk1fzhAVoNjDBuPVxiwvGuPQq3fsBMCxuDJwmX87tM/AXoadhHRljg==
-  dependencies:
-    "@typescript-eslint/types" "4.28.2"
-    "@typescript-eslint/visitor-keys" "4.28.2"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@4.28.4":
   version "4.28.4"
@@ -1340,14 +1277,6 @@
   integrity sha512-s/aIP1XcMkEqCNcPQtl60ogUYjSM8FU2mq1O7y5cFf3Xcob1z1iXWNB6cC43Op+NGRTFgGolri6s8z/efA9i1w==
   dependencies:
     "@typescript-eslint/types" "4.16.1"
-    eslint-visitor-keys "^2.0.0"
-
-"@typescript-eslint/visitor-keys@4.28.2":
-  version "4.28.2"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.28.2.tgz#bf56a400857bb68b59b311e6d0a5fbef5c3b5130"
-  integrity sha512-aT2B4PLyyRDUVUafXzpZFoc0C9t0za4BJAKP5sgWIhG+jHECQZUEjuQSCIwZdiJJ4w4cgu5r3Kh20SOdtEBl0w==
-  dependencies:
-    "@typescript-eslint/types" "4.28.2"
     eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.28.4":


### PR DESCRIPTION
## Description
Updates to newer one-sdk version
Updates superjson mutate method calls
Update configure transition so it uses `set` mutate methods
Added reconfigure methods

## Motivation and Context

## Types of changes

- [] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
