### PR TITLE
feat: parse to cache

### DIFF
--- a/src/common/document.ts
+++ b/src/common/document.ts
@@ -1,9 +1,4 @@
-import {
-  DocumentType,
-  EXTENSIONS,
-  inferDocumentType,
-  ProfileDocumentNode,
-} from '@superfaceai/ast';
+import { DocumentType, EXTENSIONS, inferDocumentType } from '@superfaceai/ast';
 import {
   ProfileEntry,
   ProfileProviderEntry,
@@ -14,13 +9,11 @@ import {
   parseMap,
   parseProfile,
   parseProfileId,
-  Source,
 } from '@superfaceai/parser';
 import { basename, join as joinPath } from 'path';
 
 import { userError } from './error';
 import { DocumentTypeFlag } from './flags';
-import { readdir, readFile } from './io';
 
 export const DEFAULT_PROFILE_VERSION = {
   major: 1,
@@ -82,18 +75,6 @@ export const composeUsecaseName = (documentId: string): string =>
     .filter(w => w.trim() !== '')
     .map(w => w[0].toUpperCase() + w.slice(1))
     .join('');
-/**
- * Parses profile on specified path with .supr extension
- */
-export async function parseProfileDocument(
-  profilePath: string
-): Promise<ProfileDocumentNode> {
-  const parseFunction = DOCUMENT_PARSE_FUNCTION[DocumentType.PROFILE];
-  const content = await readFile(profilePath, { encoding: 'utf-8' });
-  const source = new Source(content, profilePath);
-
-  return parseFunction(source);
-}
 
 /**
  * Returns a path without extension.
@@ -113,68 +94,6 @@ export function trimExtension(path: string): string {
     case DocumentType.UNKNOWN:
       throw userError('Could not infer document type', 3);
   }
-}
-
-/**
- * Find capability ids in directory given by @param path.
- *
- * If a file is found, check its extension and add it to array of results.
- *
- * If a directory is found, treat it as a scope, look for profiles inside
- * and add them to array of results with corresponding scope.
- *
- */
-export async function findLocalCapabilities(
-  path: string,
-  capability: 'profile' | 'map',
-  withVersion = false,
-  limit = 2
-): Promise<string[]> {
-  if (!limit) {
-    return [];
-  }
-
-  const dirents = await readdir(path, {
-    withFileTypes: true,
-  });
-
-  const profiles: string[] = [];
-  for (const dirent of dirents) {
-    if (dirent.isFile()) {
-      if (
-        dirent.name.endsWith(
-          capability === 'profile'
-            ? EXTENSIONS.profile.source
-            : EXTENSIONS.map.source
-        )
-      ) {
-        const {
-          header: { version },
-        } = await parseProfileDocument(joinPath(path, dirent.name));
-
-        profiles.push(
-          withVersion
-            ? `${trimExtension(dirent.name)}@${composeVersion(version)}`
-            : trimExtension(dirent.name)
-        );
-      }
-    }
-
-    if (dirent.isDirectory()) {
-      const profilesInScope = (
-        await findLocalCapabilities(
-          joinPath(path, dirent.name),
-          capability,
-          withVersion,
-          --limit
-        )
-      ).map(profile => joinPath(dirent.name, profile));
-
-      profiles.push(...profilesInScope);
-    }
-  }
-
-  return profiles;
 }
 
 /**

--- a/src/logic/install.test.ts
+++ b/src/logic/install.test.ts
@@ -4,7 +4,6 @@ import { ok, Parser, SuperJson } from '@superfaceai/one-sdk';
 import { join } from 'path';
 import { mocked } from 'ts-jest/utils';
 
-import { parseProfileDocument } from '../common/document';
 import {
   fetchProfile,
   fetchProfileAST,
@@ -26,12 +25,6 @@ jest.mock('../common/http', () => ({
   fetchProfileInfo: jest.fn(),
   fetchProfile: jest.fn(),
   fetchProfileAST: jest.fn(),
-}));
-
-//Mock document
-jest.mock('../common/document', () => ({
-  ...jest.requireActual<Record<string, unknown>>('../common/document'),
-  parseProfileDocument: jest.fn(),
 }));
 
 jest.mock('../common/io', () => ({
@@ -554,7 +547,7 @@ describe('Install CLI logic', () => {
     });
 
     it('returns correct id and version from file', async () => {
-      mocked(parseProfileDocument).mockResolvedValue({
+      jest.spyOn(Parser, 'parseProfile').mockResolvedValue({
         header: {
           kind: 'ProfileHeader',
           name: 'test',

--- a/src/logic/install.ts
+++ b/src/logic/install.ts
@@ -11,7 +11,6 @@ import {
 import {
   composeVersion,
   META_FILE,
-  parseProfileDocument,
   SUPER_PATH,
   SUPERFACE_DIR,
   trimExtension,
@@ -486,10 +485,12 @@ export async function getExistingProfileIds(
 
         if ('file' in profileSettings) {
           try {
-            //TODO: we could get ast here
-            const { header } = await parseProfileDocument(
-              superJson.resolvePath(profileSettings.file)
-            );
+            const filePath = superJson.resolvePath(profileSettings.file);
+            const content = await readFile(filePath, { encoding: 'utf-8' });
+            const { header } = await Parser.parseProfile(content, filePath, {
+              profileName: profileId.name,
+              scope: profileId.scope,
+            });
 
             return {
               profileId: ProfileId.fromScopeName(header.scope, header.name),


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR refactors document file and updates install to use Parser to cache for parsing. Only command not using Parser to cache is Lint.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
