### PR TITLE
feat: create command file name flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Do not touch .env by default
 - Hide interactive install command
 
+### Added
+- Create command file names flags
+
 ## [0.0.23] - 2021-09-07
 ### Added
 - Generate command

--- a/README.md
+++ b/README.md
@@ -134,35 +134,41 @@ USAGE
   $ superface create
 
 OPTIONS
-  -h, --help                   show CLI help
-  -i, --interactive            When set to true, command is used in interactive mode.
-  -p, --path=path              Base path where files will be created
-  -q, --quiet                  When set to true, disables the shell echo output of action.
+  -h, --help                           show CLI help
+  -i, --interactive                    When set to true, command is used in interactive mode.
+  -p, --path=path                      Base path where files will be created
+  -q, --quiet                          When set to true, disables the shell echo output of action.
 
-  -s, --scan=scan              When number provided, scan for super.json outside cwd within range represented by this
-                               number.
+  -s, --scan=scan                      When number provided, scan for super.json outside cwd within range represented by
+                                       this number.
 
-  -t, --variant=variant        Variant of a map
+  -t, --variant=variant                Variant of a map
 
-  -u, --usecase=usecase        Usecases that profile or map contains
+  -u, --usecase=usecase                Usecases that profile or map contains
 
-  -v, --version=version        [default: 1.0.0] Version of a profile
+  -v, --version=version                [default: 1.0.0] Version of a profile
 
-  --init                       When set to true, command will initialize Superface
+  --init                               When set to true, command will initialize Superface
 
-  --map                        Create a map
+  --map                                Create a map
 
-  --no-init                    When set to true, command won't initialize Superface
+  --mapFileName=mapFileName            Name of map file without extension
 
-  --no-super-json              When set to true, command won't change SuperJson file
+  --no-init                            When set to true, command won't initialize Superface
 
-  --profile                    Create a profile
+  --no-super-json                      When set to true, command won't change SuperJson file
 
-  --profileId=profileId        Profile Id in format [scope](optional)/[name]
+  --profile                            Create a profile
 
-  --provider                   Create a provider
+  --profileFileName=profileFileName    Name of profile file without extension
 
-  --providerName=providerName  Names of providers. This argument is used to create maps and/or providers
+  --profileId=profileId                Profile Id in format [scope](optional)/[name]
+
+  --provider                           Create a provider
+
+  --providerFileName=providerFileName  Name of provider file without extension
+
+  --providerName=providerName          Names of providers. This argument is used to create maps and/or providers
 
 EXAMPLES
   $ superface create --profileId sms/service --profile

--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ EXAMPLES
   $ superface create --profileId sms/service --providerName twilio --map
   $ superface create --profileId sms/service --providerName twilio --map -t bugfix
   $ superface create --providerName twilio tyntec --provider
+  $ superface create --providerName twilio --provider --providerFileName my-provider -p my/path
   $ superface create --profileId sms/service --providerName twilio --provider --map --profile -t bugfix -v 1.1-rev133 -u 
   SendSMS ReceiveSMS
   $ superface create -i

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ OPTIONS
 
   --map                                Create a map
 
-  --mapFileName=mapFileName            Name of map file without extension
+  --mapFileName=mapFileName            Name of map file
 
   --no-init                            When set to true, command won't initialize Superface
 
@@ -160,13 +160,13 @@ OPTIONS
 
   --profile                            Create a profile
 
-  --profileFileName=profileFileName    Name of profile file without extension
+  --profileFileName=profileFileName    Name of profile file
 
   --profileId=profileId                Profile Id in format [scope](optional)/[name]
 
   --provider                           Create a provider
 
-  --providerFileName=providerFileName  Name of provider file without extension
+  --providerFileName=providerFileName  Name of provider file
 
   --providerName=providerName          Names of providers. This argument is used to create maps and/or providers
 

--- a/src/commands/create.test.ts
+++ b/src/commands/create.test.ts
@@ -59,10 +59,8 @@ describe('Create CLI command', () => {
           scope: undefined,
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        //Do not pass the super path
-        undefined,
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: undefined },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
       expect(promptSpy).not.toHaveBeenCalled();
@@ -93,9 +91,8 @@ describe('Create CLI command', () => {
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
         //Pass the super path
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
       expect(promptSpy).not.toHaveBeenCalled();
@@ -132,9 +129,8 @@ describe('Create CLI command', () => {
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
         //Pass the super path
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
       expect(promptSpy).toHaveBeenCalledTimes(1);
@@ -169,10 +165,8 @@ describe('Create CLI command', () => {
           scope: undefined,
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        //Do not pass the super path
-        undefined,
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: undefined },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
       expect(promptSpy).toHaveBeenCalledTimes(1);
@@ -209,10 +203,8 @@ describe('Create CLI command', () => {
           scope: undefined,
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        //Do not pass the super path
-        undefined,
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: undefined },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
       //We prompt user and init SF but not pass path to create logic
@@ -237,9 +229,8 @@ describe('Create CLI command', () => {
           scope: undefined,
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: undefined, warnCb: undefined }
       );
     });
@@ -262,8 +253,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -293,9 +284,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -330,9 +320,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: 'rev133', major: 1, minor: 1, patch: undefined },
         },
-        'superface',
-        //Pass the base path
-        'test',
+        { basePath: 'test', superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -364,9 +353,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -402,9 +390,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -427,9 +414,8 @@ describe('Create CLI command', () => {
           scope: undefined,
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -453,9 +439,8 @@ describe('Create CLI command', () => {
           scope: undefined,
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -489,9 +474,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -528,9 +512,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -569,9 +552,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: 'rev133', major: 1, minor: 1, patch: undefined },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -605,9 +587,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -641,9 +622,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -679,9 +659,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -715,9 +694,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -751,9 +729,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -787,9 +764,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -822,9 +798,52 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
+        { logCb: expect.anything(), warnCb: expect.anything() }
+      );
+    });
+
+    it('creates profile & map with one provider and file names flags', async () => {
+      const mockProfileFileName = 'test-profile'
+      const mockProviderFileName = 'test-provider'
+      const mockMapFileName = 'test-map'
+
+      mocked(initSuperface).mockResolvedValue(new SuperJson({}));
+      jest.spyOn(inquirer, 'prompt').mockResolvedValueOnce({ init: true });
+
+      documentName = 'sms/service';
+      provider = 'twilio';
+      await expect(
+        Create.run([
+          '--profileId',
+          documentName,
+          '--providerName',
+          provider,
+          '--map',
+          '--profile',
+          '--provider',
+          '--mapFileName',
+          mockMapFileName,
+          '--profileFileName',
+          mockProfileFileName,
+          '--providerFileName',
+          mockProviderFileName
+        ])
+      ).resolves.toBeUndefined();
+
+      expect(create).toHaveBeenCalledTimes(1);
+      expect(create).toHaveBeenCalledWith(
+        { createProfile: true, createMap: true, createProvider: true },
+        ['Service'],
+        {
+          name: 'service',
+          providerNames: ['twilio'],
+          scope: 'sms',
+          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+        },
+        { basePath: undefined, superPath: 'superface' },
+        { map: mockMapFileName, profile: mockProfileFileName, provider: mockProviderFileName },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -861,9 +880,8 @@ describe('Create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Pass the base path
-        path,
+        { basePath: path, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
       expect(mkdirQuiet).not.toHaveBeenCalled();
@@ -888,7 +906,7 @@ describe('Create CLI command', () => {
     });
 
     it('throws error on missing profileId and providerNamse', async () => {
-      await expect(Create.run(['test'])).rejects.toEqual(
+      await expect(Create.run([])).rejects.toEqual(
         new CLIError('Invalid command! Specify profileId or providerName')
       );
     });

--- a/src/commands/create.test.ts
+++ b/src/commands/create.test.ts
@@ -805,9 +805,9 @@ describe('Create CLI command', () => {
     });
 
     it('creates profile & map with one provider and file names flags', async () => {
-      const mockProfileFileName = 'test-profile'
-      const mockProviderFileName = 'test-provider'
-      const mockMapFileName = 'test-map'
+      const mockProfileFileName = 'test-profile';
+      const mockProviderFileName = 'test-provider';
+      const mockMapFileName = 'test-map';
 
       mocked(initSuperface).mockResolvedValue(new SuperJson({}));
       jest.spyOn(inquirer, 'prompt').mockResolvedValueOnce({ init: true });
@@ -828,7 +828,7 @@ describe('Create CLI command', () => {
           '--profileFileName',
           mockProfileFileName,
           '--providerFileName',
-          mockProviderFileName
+          mockProviderFileName,
         ])
       ).resolves.toBeUndefined();
 
@@ -843,7 +843,11 @@ describe('Create CLI command', () => {
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
         { basePath: undefined, superPath: 'superface' },
-        { map: mockMapFileName, profile: mockProfileFileName, provider: mockProviderFileName },
+        {
+          map: mockMapFileName,
+          profile: mockProfileFileName,
+          provider: mockProviderFileName,
+        },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -884,6 +888,68 @@ describe('Create CLI command', () => {
         { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
+      expect(mkdirQuiet).not.toHaveBeenCalled();
+    });
+
+    it('throws error on mutiple provider names and single provider file name', async () => {
+      mocked(initSuperface).mockResolvedValue(new SuperJson({}));
+      mocked(exists).mockResolvedValue(true);
+      jest.spyOn(inquirer, 'prompt').mockResolvedValueOnce({ init: true });
+
+      documentName = 'sms/service';
+      const path = 'some';
+      await expect(
+        Create.run([
+          '--profileId',
+          documentName,
+          '--providerName',
+          'first',
+          'second',
+          '--provider',
+          '--path',
+          path,
+          '--providerFileName',
+          'test',
+        ])
+      ).rejects.toEqual(
+        new CLIError(
+          'Unable to create mutiple providers with same file name: "test"'
+        )
+      );
+
+      expect(create).not.toHaveBeenCalled();
+      expect(mkdirQuiet).not.toHaveBeenCalled();
+    });
+
+    it('throws error on mutiple provider names and single map file name', async () => {
+      mocked(initSuperface).mockResolvedValue(new SuperJson({}));
+      mocked(exists).mockResolvedValue(true);
+      jest.spyOn(inquirer, 'prompt').mockResolvedValueOnce({ init: true });
+
+      documentName = 'sms/service';
+      const path = 'some';
+      await expect(
+        Create.run([
+          '--profileId',
+          documentName,
+          '--providerName',
+          'first',
+          'second',
+          '--map',
+          '--profile',
+          '--provider',
+          '--path',
+          path,
+          '--mapFileName',
+          'test',
+        ])
+      ).rejects.toEqual(
+        new CLIError(
+          'Unable to create mutiple maps with same file name: "test"'
+        )
+      );
+
+      expect(create).not.toHaveBeenCalled();
       expect(mkdirQuiet).not.toHaveBeenCalled();
     });
 

--- a/src/commands/create.test.ts
+++ b/src/commands/create.test.ts
@@ -52,15 +52,23 @@ describe('Create CLI command', () => {
       ).resolves.toBeUndefined();
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: false, createProvider: false },
-        ['Sendsms'],
         {
-          name: 'sendsms',
-          scope: undefined,
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: false,
+          provider: false,
+          document: {
+            name: 'sendsms',
+            scope: undefined,
+            usecases: ['Sendsms'],
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: undefined },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: undefined },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
       expect(promptSpy).not.toHaveBeenCalled();
@@ -83,16 +91,25 @@ describe('Create CLI command', () => {
       ).resolves.toBeUndefined();
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: false, createProvider: false },
-        ['SendSMS'],
         {
-          name: 'sendsms',
-          scope: undefined,
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: false,
+          provider: false,
+          document: {
+            name: 'sendsms',
+            scope: undefined,
+            usecases: ['SendSMS'],
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths:
+            //Pass the super path
+            { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        //Pass the super path
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
       expect(promptSpy).not.toHaveBeenCalled();
@@ -120,17 +137,26 @@ describe('Create CLI command', () => {
       ).resolves.toBeUndefined();
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: false, createMap: true, createProvider: false },
-        ['SendSMS'],
         {
-          name: 'sendsms',
-          providerNames: [provider],
-          scope: undefined,
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: false,
+          map: true,
+          provider: false,
+          document: {
+            name: 'sendsms',
+            providerNames: [provider],
+            usecases: ['SendSMS'],
+            scope: undefined,
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths:
+            //Pass the super path
+            { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        //Pass the super path
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
       expect(promptSpy).toHaveBeenCalledTimes(1);
@@ -157,16 +183,24 @@ describe('Create CLI command', () => {
       ).resolves.toBeUndefined();
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: false, createMap: true, createProvider: false },
-        ['SendSMS'],
         {
-          name: 'sendsms',
-          providerNames: [provider],
-          scope: undefined,
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: false,
+          map: true,
+          provider: false,
+          document: {
+            name: 'sendsms',
+            providerNames: [provider],
+            usecases: ['SendSMS'],
+            scope: undefined,
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: undefined },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: undefined },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
       expect(promptSpy).toHaveBeenCalledTimes(1);
@@ -195,16 +229,24 @@ describe('Create CLI command', () => {
       ).resolves.toBeUndefined();
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: false, createMap: true, createProvider: false },
-        ['SendSMS'],
         {
-          name: 'sendsms',
-          providerNames: [provider],
-          scope: undefined,
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: false,
+          map: true,
+          provider: false,
+          document: {
+            name: 'sendsms',
+            providerNames: [provider],
+            usecases: ['SendSMS'],
+            scope: undefined,
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: undefined },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: undefined },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
       //We prompt user and init SF but not pass path to create logic
@@ -222,15 +264,23 @@ describe('Create CLI command', () => {
       ).resolves.toBeUndefined();
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: false, createProvider: false },
-        ['Sendsms'],
         {
-          name: 'sendsms',
-          scope: undefined,
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: false,
+          provider: false,
+          document: {
+            name: 'sendsms',
+            usecases: ['Sendsms'],
+            scope: undefined,
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: undefined, warnCb: undefined }
       );
     });
@@ -246,15 +296,23 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: false, createProvider: false },
-        ['SendSMS'],
         {
-          name: 'service',
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: false,
+          provider: false,
+          document: {
+            name: 'service',
+            usecases: ['SendSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -277,15 +335,23 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: false, createProvider: false },
-        ['ReceiveSMS', 'SendSMS'],
         {
-          name: 'service',
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: false,
+          provider: false,
+          document: {
+            name: 'service',
+            usecases: ['ReceiveSMS', 'SendSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -313,15 +379,23 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: false, createProvider: false },
-        ['ReceiveSMS', 'SendSMS'],
         {
-          name: 'service',
-          scope: 'sms',
-          version: { label: 'rev133', major: 1, minor: 1, patch: undefined },
+          profile: true,
+          map: false,
+          provider: false,
+          document: {
+            name: 'service',
+            usecases: ['ReceiveSMS', 'SendSMS'],
+            scope: 'sms',
+            version: { label: 'rev133', major: 1, minor: 1, patch: undefined },
+          },
+          paths: { basePath: 'test', superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: 'test', superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -345,16 +419,24 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: false, createMap: true, createProvider: false },
-        ['Service'],
         {
-          name: 'service',
-          providerNames: [provider],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: false,
+          map: true,
+          provider: false,
+          document: {
+            name: 'service',
+            providerNames: [provider],
+            usecases: ['Service'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -382,16 +464,24 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: false, createMap: true, createProvider: false },
-        ['ReceiveSMS', 'SendSMS'],
         {
-          name: 'service',
-          providerNames: [provider, secondProvider],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: false,
+          map: true,
+          provider: false,
+          document: {
+            name: 'service',
+            usecases: ['ReceiveSMS', 'SendSMS'],
+            providerNames: [provider, secondProvider],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -407,15 +497,23 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: false, createMap: false, createProvider: true },
-        [],
         {
-          providerNames: [provider],
-          scope: undefined,
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: false,
+          map: false,
+          provider: true,
+          document: {
+            providerNames: [provider],
+            usecases: [],
+            scope: undefined,
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -432,15 +530,23 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: false, createMap: false, createProvider: true },
-        [],
         {
-          providerNames: [provider, secondProvider],
-          scope: undefined,
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: false,
+          map: false,
+          provider: true,
+          document: {
+            providerNames: [provider, secondProvider],
+            usecases: [],
+            scope: undefined,
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -466,16 +572,24 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: false, createProvider: true },
-        ['SendSMS'],
         {
-          name: 'service',
-          providerNames: [provider],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: false,
+          provider: true,
+          document: {
+            name: 'service',
+            providerNames: [provider],
+            usecases: ['SendSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -504,16 +618,24 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: false, createProvider: true },
-        ['SendSMS', 'ReciveSMS'],
         {
-          name: 'service',
-          providerNames: [provider, secondProvider],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: false,
+          provider: true,
+          document: {
+            name: 'service',
+            providerNames: [provider, secondProvider],
+            usecases: ['SendSMS', 'ReciveSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -544,16 +666,24 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: false, createProvider: true },
-        ['SendSMS', 'ReciveSMS'],
         {
-          name: 'service',
-          providerNames: [provider, secondProvider],
-          scope: 'sms',
-          version: { label: 'rev133', major: 1, minor: 1, patch: undefined },
+          profile: true,
+          map: false,
+          provider: true,
+          document: {
+            name: 'service',
+            providerNames: [provider, secondProvider],
+            usecases: ['SendSMS', 'ReciveSMS'],
+            scope: 'sms',
+            version: { label: 'rev133', major: 1, minor: 1, patch: undefined },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -579,16 +709,24 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: true, createProvider: false },
-        ['SendSMS'],
         {
-          name: 'service',
-          providerNames: [provider],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: true,
+          provider: false,
+          document: {
+            name: 'service',
+            providerNames: [provider],
+            usecases: ['SendSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -614,16 +752,24 @@ describe('Create CLI command', () => {
       ).resolves.toBeUndefined();
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: true, createProvider: false },
-        ['SendSMS', 'ReceiveSMS'],
         {
-          name: 'service',
-          providerNames: [provider],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: true,
+          provider: false,
+          document: {
+            name: 'service',
+            providerNames: [provider],
+            usecases: ['SendSMS', 'ReceiveSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -651,16 +797,24 @@ describe('Create CLI command', () => {
       ).resolves.toBeUndefined();
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: true, createProvider: false },
-        ['SendSMS', 'ReceiveSMS'],
         {
-          name: 'service',
-          providerNames: [provider, secondProvider],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: true,
+          provider: false,
+          document: {
+            name: 'service',
+            providerNames: [provider, secondProvider],
+            usecases: ['SendSMS', 'ReceiveSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -685,17 +839,25 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: false, createMap: true, createProvider: false },
-        ['Service'],
         {
-          name: 'service',
-          providerNames: [provider],
-          variant: 'bugfix',
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: false,
+          map: true,
+          provider: false,
+          document: {
+            name: 'service',
+            providerNames: [provider],
+            usecases: ['Service'],
+            variant: 'bugfix',
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -721,16 +883,24 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: false, createMap: true, createProvider: true },
-        ['SendSMS'],
         {
-          name: 'service',
-          providerNames: [provider],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: false,
+          map: true,
+          provider: true,
+          document: {
+            name: 'service',
+            providerNames: [provider],
+            usecases: ['SendSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -756,16 +926,24 @@ describe('Create CLI command', () => {
       ).resolves.toBeUndefined();
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: false, createMap: true, createProvider: true },
-        ['ReceiveSMS', 'SendSMS'],
         {
-          name: 'service',
-          providerNames: [provider],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: false,
+          map: true,
+          provider: true,
+          document: {
+            name: 'service',
+            providerNames: [provider],
+            usecases: ['ReceiveSMS', 'SendSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -790,16 +968,24 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: true, createProvider: true },
-        ['Service'],
         {
-          name: 'service',
-          providerNames: ['twilio'],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: true,
+          provider: true,
+          document: {
+            name: 'service',
+            providerNames: ['twilio'],
+            usecases: ['Service'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -834,19 +1020,23 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: true, createProvider: true },
-        ['Service'],
         {
-          name: 'service',
-          providerNames: ['twilio'],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
-        },
-        { basePath: undefined, superPath: 'superface' },
-        {
-          map: mockMapFileName,
-          profile: mockProfileFileName,
-          provider: mockProviderFileName,
+          profile: true,
+          map: true,
+          provider: true,
+          document: {
+            name: 'service',
+            providerNames: ['twilio'],
+            usecases: ['Service'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: mockMapFileName,
+            profile: mockProfileFileName,
+            provider: mockProviderFileName,
+          },
         },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
@@ -876,16 +1066,24 @@ describe('Create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: true, createProvider: true },
-        ['Service'],
         {
-          name: 'service',
-          providerNames: ['twilio'],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: true,
+          provider: true,
+          document: {
+            name: 'service',
+            providerNames: ['twilio'],
+            usecases: ['Service'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: path, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: path, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
       expect(mkdirQuiet).not.toHaveBeenCalled();

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -121,8 +121,8 @@ export default class Create extends Command {
     '$ superface create -i',
   ];
 
-  private warnCallback?= (message: string) => this.log(yellow(message));
-  private logCallback?= (message: string) => this.log(grey(message));
+  private warnCallback? = (message: string) => this.log(yellow(message));
+  private logCallback? = (message: string) => this.log(grey(message));
 
   async run(): Promise<void> {
     const { flags } = this.parse(Create);
@@ -179,7 +179,8 @@ export default class Create extends Command {
         ]);
         while (!exit) {
           const providerInput = await this.inputPrompt(
-            `Enter provider name of ${priorityToString.get(priority) || priority
+            `Enter provider name of ${
+              priorityToString.get(priority) || priority
             } provider.\nExit loop by pressing enter without any input.`
           );
           if (!providerInput) {
@@ -373,26 +374,26 @@ export default class Create extends Command {
 
     await create(
       {
-        createProvider: !!flags.provider,
-        createMap: !!flags.map,
-        createProfile: !!flags.profile,
-      },
-      usecases,
-      {
-        scope,
-        version,
-        providerNames,
-        name,
-        variant: flags.variant,
-      },
-      {
-        superPath,
-        basePath: flags.path,
-      },
-      {
-        map: flags.mapFileName,
-        profile: flags.profileFileName,
-        provider: flags.providerFileName,
+        provider: !!flags.provider,
+        map: !!flags.map,
+        profile: !!flags.profile,
+        fileNames: {
+          map: flags.mapFileName,
+          profile: flags.profileFileName,
+          provider: flags.providerFileName,
+        },
+        paths: {
+          superPath,
+          basePath: flags.path,
+        },
+        document: {
+          scope,
+          version,
+          providerNames,
+          usecases,
+          name,
+          variant: flags.variant,
+        },
       },
       {
         logCb: this.logCallback,

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -24,7 +24,7 @@ import { initSuperface } from '../logic/init';
 import { detectSuperJson } from '../logic/install';
 
 export default class Create extends Command {
-  static strict = false;
+  static strict = true;
 
   static description =
     'Creates empty map, profile or/and provider on a local filesystem.';
@@ -90,6 +90,18 @@ export default class Create extends Command {
       default: undefined,
       description: 'Base path where files will be created',
     }),
+    mapFileName: oclifFlags.string({
+      default: undefined,
+      description: 'Name of map file without extension',
+    }),
+    profileFileName: oclifFlags.string({
+      default: undefined,
+      description: 'Name of profile file without extension',
+    }),
+    providerFileName: oclifFlags.string({
+      default: undefined,
+      description: 'Name of provider file without extension',
+    }),
     scan: oclifFlags.integer({
       char: 's',
       description:
@@ -108,8 +120,8 @@ export default class Create extends Command {
     '$ superface create -i',
   ];
 
-  private warnCallback? = (message: string) => this.log(yellow(message));
-  private logCallback? = (message: string) => this.log(grey(message));
+  private warnCallback?= (message: string) => this.log(yellow(message));
+  private logCallback?= (message: string) => this.log(grey(message));
 
   async run(): Promise<void> {
     const { flags } = this.parse(Create);
@@ -166,8 +178,7 @@ export default class Create extends Command {
         ]);
         while (!exit) {
           const providerInput = await this.inputPrompt(
-            `Enter provider name of ${
-              priorityToString.get(priority) || priority
+            `Enter provider name of ${priorityToString.get(priority) || priority
             } provider.\nExit loop by pressing enter without any input.`
           );
           if (!providerInput) {
@@ -195,16 +206,13 @@ export default class Create extends Command {
     let providerNames: string[] = [];
 
     //Check inputs
-    if (flags.profile && !flags.profileId) {
-      throw userError('--profileId= must be provided when creating profile', 1);
-    }
     if (flags.map && !flags.profileId) {
       throw userError('--profileId= must be provided when creating map', 1);
     }
     if (flags.map && !flags.providerName) {
       throw userError('--providerName= must be provided when creating map', 1);
     }
-    if (flags.providerName && !flags.providerName) {
+    if (flags.provider && !flags.providerName) {
       throw userError(
         '--providerName= must be provided when creating provider',
         1
@@ -236,6 +244,19 @@ export default class Create extends Command {
     }
     providerNames = flags.providerName;
 
+    if (flags.providerFileName && providerNames.length > 1) {
+      throw userError(
+        `Unable to create mutiple providers with same file name: "${flags.providerFileName}"`,
+        1
+      );
+    }
+
+    if (flags.mapFileName && providerNames.length > 1) {
+      throw userError(
+        `Unable to create mutiple maps with same file name: "${flags.mapFileName}"`,
+        1
+      );
+    }
     // output a warning when generating profile only and provider is specified
     if (flags.profile && !flags.map && !flags.provider && flags.providerName) {
       this.warn(
@@ -363,8 +384,15 @@ export default class Create extends Command {
         name,
         variant: flags.variant,
       },
-      superPath,
-      flags.path,
+      {
+        superPath,
+        basePath: flags.path,
+      },
+      {
+        map: flags.mapFileName,
+        profile: flags.profileFileName,
+        provider: flags.providerFileName,
+      },
       {
         logCb: this.logCallback,
         warnCb: this.warnCallback,

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -92,15 +92,15 @@ export default class Create extends Command {
     }),
     mapFileName: oclifFlags.string({
       default: undefined,
-      description: 'Name of map file without extension',
+      description: 'Name of map file',
     }),
     profileFileName: oclifFlags.string({
       default: undefined,
-      description: 'Name of profile file without extension',
+      description: 'Name of profile file',
     }),
     providerFileName: oclifFlags.string({
       default: undefined,
-      description: 'Name of provider file without extension',
+      description: 'Name of provider file',
     }),
     scan: oclifFlags.integer({
       char: 's',

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -116,12 +116,13 @@ export default class Create extends Command {
     '$ superface create --profileId sms/service --providerName twilio --map',
     '$ superface create --profileId sms/service --providerName twilio --map -t bugfix',
     '$ superface create --providerName twilio tyntec --provider',
+    '$ superface create --providerName twilio --provider --providerFileName my-provider -p my/path',
     '$ superface create --profileId sms/service --providerName twilio --provider --map --profile -t bugfix -v 1.1-rev133 -u SendSMS ReceiveSMS',
     '$ superface create -i',
   ];
 
-  private warnCallback? = (message: string) => this.log(yellow(message));
-  private logCallback? = (message: string) => this.log(grey(message));
+  private warnCallback?= (message: string) => this.log(yellow(message));
+  private logCallback?= (message: string) => this.log(grey(message));
 
   async run(): Promise<void> {
     const { flags } = this.parse(Create);
@@ -178,8 +179,7 @@ export default class Create extends Command {
         ]);
         while (!exit) {
           const providerInput = await this.inputPrompt(
-            `Enter provider name of ${
-              priorityToString.get(priority) || priority
+            `Enter provider name of ${priorityToString.get(priority) || priority
             } provider.\nExit loop by pressing enter without any input.`
           );
           if (!providerInput) {

--- a/src/commands/create.ts
+++ b/src/commands/create.ts
@@ -120,8 +120,8 @@ export default class Create extends Command {
     '$ superface create -i',
   ];
 
-  private warnCallback?= (message: string) => this.log(yellow(message));
-  private logCallback?= (message: string) => this.log(grey(message));
+  private warnCallback? = (message: string) => this.log(yellow(message));
+  private logCallback? = (message: string) => this.log(grey(message));
 
   async run(): Promise<void> {
     const { flags } = this.parse(Create);
@@ -178,7 +178,8 @@ export default class Create extends Command {
         ]);
         while (!exit) {
           const providerInput = await this.inputPrompt(
-            `Enter provider name of ${priorityToString.get(priority) || priority
+            `Enter provider name of ${
+              priorityToString.get(priority) || priority
             } provider.\nExit loop by pressing enter without any input.`
           );
           if (!providerInput) {

--- a/src/commands/interactive.create.test.ts
+++ b/src/commands/interactive.create.test.ts
@@ -59,9 +59,8 @@ describe('Interactive create CLI command', () => {
           scope: undefined,
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Pass the base path
-        'test',
+        { basePath: 'test', superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -95,9 +94,8 @@ describe('Interactive create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -132,9 +130,8 @@ describe('Interactive create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -173,9 +170,8 @@ describe('Interactive create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -214,9 +210,8 @@ describe('Interactive create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -256,9 +251,8 @@ describe('Interactive create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -297,9 +291,8 @@ describe('Interactive create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -337,9 +330,8 @@ describe('Interactive create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -379,9 +371,8 @@ describe('Interactive create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -420,15 +411,14 @@ describe('Interactive create CLI command', () => {
           scope: 'sms',
           version: { label: undefined, major: 1, minor: 0, patch: 0 },
         },
-        'superface',
-        //Do not pass the base path
-        undefined,
+        { basePath: undefined, superPath: 'superface' },
+        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
 
     it('throws error on invalid command', async () => {
-      await expect(Create.run(['profile'])).rejects.toEqual(
+      await expect(Create.run([])).rejects.toEqual(
         new CLIError('Invalid command! Specify profileId or providerName')
       );
     });

--- a/src/commands/interactive.create.test.ts
+++ b/src/commands/interactive.create.test.ts
@@ -52,15 +52,23 @@ describe('Interactive create CLI command', () => {
       await expect(Create.run(['-i', '-p', 'test'])).resolves.toBeUndefined();
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: false, createProvider: false },
-        ['Sendsms'],
         {
-          name: 'sendsms',
-          scope: undefined,
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: false,
+          provider: false,
+          document: {
+            name: 'sendsms',
+            usecases: ['Sendsms'],
+            scope: undefined,
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: 'test', superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: 'test', superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -87,15 +95,23 @@ describe('Interactive create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: false, createProvider: false },
-        ['SendSMS'],
         {
-          name: 'service',
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: false,
+          provider: false,
+          document: {
+            name: 'service',
+            usecases: ['SendSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -123,15 +139,23 @@ describe('Interactive create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: false, createProvider: false },
-        ['ReceiveSMS', 'SendSMS'],
         {
-          name: 'service',
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: false,
+          provider: false,
+          document: {
+            name: 'service',
+            usecases: ['ReceiveSMS', 'SendSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -161,17 +185,25 @@ describe('Interactive create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: false, createMap: true, createProvider: false },
-        ['Service'],
         {
-          name: 'service',
-          providerNames: ['twilio'],
-          variant: 'bugfix',
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: false,
+          map: true,
+          provider: false,
+          document: {
+            name: 'service',
+            providerNames: ['twilio'],
+            usecases: ['Service'],
+            variant: 'bugfix',
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -201,17 +233,25 @@ describe('Interactive create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: false, createMap: true, createProvider: false },
-        ['Service'],
         {
-          name: 'service',
-          providerNames: ['twilio', 'tyntec'],
-          variant: 'bugfix',
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: false,
+          map: true,
+          provider: false,
+          document: {
+            name: 'service',
+            providerNames: ['twilio', 'tyntec'],
+            usecases: ['Service'],
+            variant: 'bugfix',
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -243,16 +283,24 @@ describe('Interactive create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: false, createMap: true, createProvider: true },
-        ['SendSMS'],
         {
-          name: 'service',
-          providerNames: ['twilio'],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: false,
+          map: true,
+          provider: true,
+          document: {
+            name: 'service',
+            providerNames: ['twilio'],
+            usecases: ['SendSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -283,16 +331,24 @@ describe('Interactive create CLI command', () => {
       ).resolves.toBeUndefined();
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: false, createMap: true, createProvider: true },
-        ['ReceiveSMS', 'SendSMS'],
         {
-          name: 'service',
-          providerNames: ['twilio'],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: false,
+          map: true,
+          provider: true,
+          document: {
+            name: 'service',
+            providerNames: ['twilio'],
+            usecases: ['ReceiveSMS', 'SendSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -322,16 +378,24 @@ describe('Interactive create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: true, createProvider: true },
-        ['Service'],
         {
-          name: 'service',
-          providerNames: ['twilio'],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: true,
+          provider: true,
+          document: {
+            name: 'service',
+            providerNames: ['twilio'],
+            usecases: ['Service'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -363,16 +427,24 @@ describe('Interactive create CLI command', () => {
 
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: true, createProvider: false },
-        ['SendSMS'],
         {
-          name: 'service',
-          providerNames: ['twilio'],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: true,
+          provider: false,
+          document: {
+            name: 'service',
+            providerNames: ['twilio'],
+            usecases: ['SendSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });
@@ -403,16 +475,24 @@ describe('Interactive create CLI command', () => {
       ).resolves.toBeUndefined();
       expect(create).toHaveBeenCalledTimes(1);
       expect(create).toHaveBeenCalledWith(
-        { createProfile: true, createMap: true, createProvider: false },
-        ['SendSMS', 'ReceiveSMS'],
         {
-          name: 'service',
-          providerNames: ['twilio'],
-          scope: 'sms',
-          version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          profile: true,
+          map: true,
+          provider: false,
+          document: {
+            name: 'service',
+            providerNames: ['twilio'],
+            usecases: ['SendSMS', 'ReceiveSMS'],
+            scope: 'sms',
+            version: { label: undefined, major: 1, minor: 0, patch: 0 },
+          },
+          paths: { basePath: undefined, superPath: 'superface' },
+          fileNames: {
+            map: undefined,
+            profile: undefined,
+            provider: undefined,
+          },
         },
-        { basePath: undefined, superPath: 'superface' },
-        { map: undefined, profile: undefined, provider: undefined },
         { logCb: expect.anything(), warnCb: expect.anything() }
       );
     });

--- a/src/logic/create.test.ts
+++ b/src/logic/create.test.ts
@@ -397,10 +397,11 @@ describe('Create logic', () => {
     const mockSuperPath = 'test-super-path';
     const mockUsecases = ['usecase'];
     const mockFilename = 'test-filename';
-    let mockDocumentStructure: {
+    let document: {
       scope?: string;
       name?: string;
       providerNames: string[];
+      usecases: string[];
       version: {
         major: number;
         minor: number;
@@ -412,10 +413,11 @@ describe('Create logic', () => {
 
     beforeEach(() => {
       mockSuperJson = new SuperJson({});
-      mockDocumentStructure = {
+      document = {
         scope: mockScope,
         name: mockName,
         providerNames: [mockProvider],
+        usecases: mockUsecases,
         version: {
           major: 1,
           minor: 0,
@@ -435,14 +437,15 @@ describe('Create logic', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        create(
-          { createProfile: false, createMap: false, createProvider: true },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: false,
+          map: false,
+          provider: true,
+          document: document,
+          paths: {
             superPath: mockSuperPath,
-          }
-        )
+          },
+        })
       ).resolves.toBeUndefined();
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -476,17 +479,18 @@ describe('Create logic', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        create(
-          { createProfile: false, createMap: false, createProvider: true },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: false,
+          map: false,
+          provider: true,
+          document: document,
+          paths: {
             superPath: mockSuperPath,
           },
-          {
+          fileNames: {
             provider: mockFilename,
-          }
-        )
+          },
+        })
       ).resolves.toBeUndefined();
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -519,17 +523,18 @@ describe('Create logic', () => {
         .spyOn(OutputStream, 'writeOnce')
         .mockResolvedValue(undefined);
 
-      mockDocumentStructure.providerNames = [mockProvider, secondMockProvider];
+      document.providerNames = [mockProvider, secondMockProvider];
 
       await expect(
-        create(
-          { createProfile: false, createMap: false, createProvider: true },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: false,
+          map: false,
+          provider: true,
+          document,
+          paths: {
             superPath: mockSuperPath,
-          }
-        )
+          },
+        })
       ).resolves.toBeUndefined();
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -574,14 +579,15 @@ describe('Create logic', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        create(
-          { createProfile: true, createMap: false, createProvider: false },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: true,
+          map: false,
+          provider: false,
+          document,
+          paths: {
             superPath: mockSuperPath,
-          }
-        )
+          },
+        })
       ).resolves.toBeUndefined();
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -623,17 +629,18 @@ describe('Create logic', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        create(
-          { createProfile: true, createMap: false, createProvider: false },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: true,
+          map: false,
+          provider: false,
+          document,
+          paths: {
             superPath: mockSuperPath,
           },
-          {
+          fileNames: {
             profile: mockFilename,
-          }
-        )
+          },
+        })
       ).resolves.toBeUndefined();
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -675,14 +682,15 @@ describe('Create logic', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        create(
-          { createProfile: true, createMap: false, createProvider: false },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: true,
+          map: false,
+          provider: false,
+          document,
+          paths: {
             superPath: mockSuperPath,
-          }
-        )
+          },
+        })
       ).resolves.toBeUndefined();
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -717,14 +725,15 @@ describe('Create logic', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        create(
-          { createProfile: false, createMap: true, createProvider: true },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: false,
+          map: true,
+          provider: true,
+          document,
+          paths: {
             superPath: mockSuperPath,
-          }
-        )
+          },
+        })
       ).resolves.toBeUndefined();
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -781,14 +790,15 @@ describe('Create logic', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        create(
-          { createProfile: false, createMap: true, createProvider: false },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: false,
+          map: true,
+          provider: false,
+          document,
+          paths: {
             superPath: mockSuperPath,
-          }
-        )
+          },
+        })
       ).resolves.toBeUndefined();
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -837,17 +847,18 @@ describe('Create logic', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        create(
-          { createProfile: false, createMap: true, createProvider: false },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: false,
+          map: true,
+          provider: false,
+          document,
+          paths: {
             superPath: mockSuperPath,
           },
-          {
+          fileNames: {
             map: mockFilename,
-          }
-        )
+          },
+        })
       ).resolves.toBeUndefined();
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -894,14 +905,15 @@ describe('Create logic', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        create(
-          { createProfile: true, createMap: true, createProvider: false },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: true,
+          map: true,
+          provider: false,
+          document,
+          paths: {
             superPath: mockSuperPath,
-          }
-        )
+          },
+        })
       ).resolves.toBeUndefined();
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -947,9 +959,10 @@ describe('Create logic', () => {
     });
 
     it('throws error when provider is missing - creating map', async () => {
-      mockDocumentStructure = {
+      document = {
         scope: mockScope,
         providerNames: [],
+        usecases: mockUsecases,
         name: mockName,
         version: {
           major: 1,
@@ -969,14 +982,15 @@ describe('Create logic', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        create(
-          { createProfile: false, createMap: true, createProvider: false },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: false,
+          map: true,
+          provider: false,
+          document,
+          paths: {
             superPath: mockSuperPath,
-          }
-        )
+          },
+        })
       ).rejects.toEqual(
         new CLIError('Provider name must be provided when generating a map.')
       );
@@ -994,9 +1008,10 @@ describe('Create logic', () => {
     });
 
     it('throws error when provider is missing - creating provider', async () => {
-      mockDocumentStructure = {
+      document = {
         scope: mockScope,
         providerNames: [],
+        usecases: mockUsecases,
         name: mockName,
         version: {
           major: 1,
@@ -1016,14 +1031,15 @@ describe('Create logic', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        create(
-          { createProfile: false, createMap: false, createProvider: true },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: false,
+          map: false,
+          provider: true,
+          document,
+          paths: {
             superPath: mockSuperPath,
-          }
-        )
+          },
+        })
       ).rejects.toEqual(
         new CLIError(
           'Provider name must be provided when generating a provider.'
@@ -1043,9 +1059,10 @@ describe('Create logic', () => {
     });
 
     it('throws error when profile name is missing - creating map', async () => {
-      mockDocumentStructure = {
+      document = {
         scope: mockScope,
         providerNames: [mockProvider],
+        usecases: mockUsecases,
         version: {
           major: 1,
           minor: 0,
@@ -1064,14 +1081,15 @@ describe('Create logic', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        create(
-          { createProfile: false, createMap: true, createProvider: false },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: false,
+          map: true,
+          provider: false,
+          document,
+          paths: {
             superPath: mockSuperPath,
-          }
-        )
+          },
+        })
       ).rejects.toEqual(
         new CLIError('Profile name must be provided when generating a map.')
       );
@@ -1089,9 +1107,10 @@ describe('Create logic', () => {
     });
 
     it('throws error when profile name is missing - creating profile', async () => {
-      mockDocumentStructure = {
+      document = {
         scope: mockScope,
         providerNames: [mockProvider],
+        usecases: mockUsecases,
         version: {
           major: 1,
           minor: 0,
@@ -1110,14 +1129,15 @@ describe('Create logic', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        create(
-          { createProfile: true, createMap: false, createProvider: false },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: true,
+          map: false,
+          provider: false,
+          document,
+          paths: {
             superPath: mockSuperPath,
-          }
-        )
+          },
+        })
       ).rejects.toEqual(
         new CLIError('Profile name must be provided when generating a profile.')
       );
@@ -1135,9 +1155,10 @@ describe('Create logic', () => {
     });
 
     it('throws error when provider is missing - creating map and profile', async () => {
-      mockDocumentStructure = {
+      document = {
         scope: mockScope,
         providerNames: [],
+        usecases: mockUsecases,
         name: mockName,
         version: {
           major: 1,
@@ -1157,14 +1178,15 @@ describe('Create logic', () => {
         .mockResolvedValue(undefined);
 
       await expect(
-        create(
-          { createProfile: true, createMap: true, createProvider: false },
-          mockUsecases,
-          mockDocumentStructure,
-          {
+        create({
+          profile: true,
+          map: true,
+          provider: false,
+          document,
+          paths: {
             superPath: mockSuperPath,
-          }
-        )
+          },
+        })
       ).rejects.toEqual(
         new CLIError('Provider name must be provided when generating a map.')
       );

--- a/src/logic/create.ts
+++ b/src/logic/create.ts
@@ -27,7 +27,12 @@ export async function createProfile(
     logCb?: LogCallback;
   }
 ): Promise<void> {
-  let filePath = `${fileName || profile.id}${EXTENSIONS.profile.source}`;
+  //Add extension if missing
+  if (fileName && !fileName.endsWith(EXTENSIONS.profile.source)) {
+    fileName = fileName + EXTENSIONS.profile.source;
+  }
+  let filePath = fileName || `${profile.id}${EXTENSIONS.profile.source}`;
+
   const versionStr = composeVersion(version);
   filePath = joinPath(basePath, filePath);
 
@@ -72,10 +77,15 @@ export async function createMap(
   }
 ): Promise<void> {
   const variantName = id.variant ? `.${id.variant}` : '';
+  //Add extension if missing
+  if (fileName && !fileName.endsWith(EXTENSIONS.map.source)) {
+    fileName = fileName + EXTENSIONS.map.source;
+  }
 
-  let filePath = `${
-    fileName || `${id.profile.id}.${id.provider}${variantName}`
-  }${EXTENSIONS.map.source}`;
+  let filePath =
+    fileName ||
+    `${id.profile.id}.${id.provider}${variantName}${EXTENSIONS.map.source}`;
+
   const version = composeVersion(id.version, true);
 
   filePath = joinPath(basePath, filePath);
@@ -115,10 +125,12 @@ export async function createProviderJson(
     logCb?: LogCallback;
   }
 ): Promise<void> {
-  const filePath = joinPath(
-    basePath,
-    fileName ? `${fileName}.json` : `${provider}.provider.json`
-  );
+  //Add extension if missing
+  if (fileName && !fileName.endsWith('.json')) {
+    fileName = `${fileName}.json`;
+  }
+
+  const filePath = joinPath(basePath, fileName || `${provider}.provider.json`);
   const created = await OutputStream.writeIfAbsent(
     filePath,
     providerTemplate.empty(provider),

--- a/src/logic/create.ts
+++ b/src/logic/create.ts
@@ -152,27 +152,28 @@ export async function createProviderJson(
  */
 export async function create(
   create: {
-    createProfile: boolean;
-    createMap: boolean;
-    createProvider: boolean;
+    profile: boolean;
+    map: boolean;
+    provider: boolean;
+    document: {
+      scope?: string;
+      name?: string;
+      providerNames: string[];
+      usecases: string[];
+      version: DocumentVersion;
+      variant?: string;
+    };
+    paths: {
+      superPath?: string;
+      basePath?: string;
+    };
+    fileNames?: {
+      provider?: string;
+      map?: string;
+      profile?: string;
+    };
   },
-  usecases: string[],
-  documentStructure: {
-    scope?: string;
-    name?: string;
-    providerNames: string[];
-    version: DocumentVersion;
-    variant?: string;
-  },
-  paths: {
-    superPath?: string;
-    basePath?: string;
-  },
-  fileNames?: {
-    provider?: string;
-    map?: string;
-    profile?: string;
-  },
+
   options?: {
     logCb?: LogCallback;
     warnCb?: LogCallback;
@@ -180,9 +181,9 @@ export async function create(
 ): Promise<void> {
   //Load super json if we have path
   let superJson: SuperJson | undefined = undefined;
-  if (paths.superPath) {
+  if (create.paths.superPath) {
     const loadedResult = await SuperJson.load(
-      joinPath(paths.superPath, META_FILE)
+      joinPath(create.paths.superPath, META_FILE)
     );
     superJson = loadedResult.match(
       v => v,
@@ -200,9 +201,10 @@ export async function create(
     providerNames: providers,
     version,
     variant,
-  } = documentStructure;
+    usecases,
+  } = create.document;
 
-  if (create.createMap) {
+  if (create.map) {
     if (providers.length === 0) {
       throw userError(
         'Provider name must be provided when generating a map.',
@@ -217,7 +219,7 @@ export async function create(
     }
     for (const provider of providers) {
       await createMap(
-        paths.basePath ?? '',
+        create.paths.basePath ?? '',
         {
           profile: ProfileId.fromScopeName(scope, name),
           provider,
@@ -226,12 +228,12 @@ export async function create(
         },
         usecases,
         superJson,
-        fileNames?.map,
+        create.fileNames?.map,
         { logCb: options?.logCb }
       );
     }
   }
-  if (create.createProvider) {
+  if (create.provider) {
     if (providers.length === 0) {
       throw userError(
         'Provider name must be provided when generating a provider.',
@@ -240,17 +242,17 @@ export async function create(
     }
     for (const provider of providers) {
       await createProviderJson(
-        paths.basePath ?? '',
+        create.paths.basePath ?? '',
         provider,
         superJson,
-        fileNames?.provider,
+        create.fileNames?.provider,
         {
           logCb: options?.logCb,
         }
       );
     }
   }
-  if (create.createProfile) {
+  if (create.profile) {
     if (!name) {
       throw userError(
         'Profile name must be provided when generating a profile.',
@@ -258,12 +260,12 @@ export async function create(
       );
     }
     await createProfile(
-      paths.basePath ?? '',
+      create.paths.basePath ?? '',
       ProfileId.fromScopeName(scope, name),
       version,
       usecases,
       superJson,
-      fileNames?.profile,
+      create.fileNames?.profile,
       {
         logCb: options?.logCb,
       }

--- a/src/logic/create.ts
+++ b/src/logic/create.ts
@@ -126,7 +126,7 @@ export async function createProviderJson(
   );
 
   if (created) {
-    options?.logCb?.(`-> Created ${provider}.provider.json`);
+    options?.logCb?.(`-> Created ${filePath}`);
     if (superJson) {
       superJson.mergeProvider(provider, {
         file: relativePath(dirname(superJson.path), filePath),

--- a/src/logic/create.ts
+++ b/src/logic/create.ts
@@ -7,6 +7,7 @@ import { composeVersion, META_FILE } from '../common/document';
 import { userError } from '../common/error';
 import { formatShellLog, LogCallback } from '../common/log';
 import { OutputStream } from '../common/output-stream';
+import { ProfileId } from '../common/profile';
 import * as mapTemplate from '../templates/map';
 import * as profileTemplate from '../templates/profile';
 import * as providerTemplate from '../templates/provider';
@@ -16,32 +17,24 @@ import * as providerTemplate from '../templates/provider';
  */
 export async function createProfile(
   basePath: string,
-  id: {
-    scope?: string;
-    name: string;
-    version: DocumentVersion;
-  },
+  profile: ProfileId,
+  version: DocumentVersion,
   usecaseNames: string[],
   superJson?: SuperJson,
+  fileName?: string,
   options?: {
     force?: boolean;
     logCb?: LogCallback;
   }
 ): Promise<void> {
-  let profileName = id.name;
-  let filePath = `${profileName}${EXTENSIONS.profile.source}`;
-  const version = composeVersion(id.version);
-
-  if (id.scope !== undefined) {
-    profileName = `${id.scope}/${profileName}`;
-    filePath = joinPath(id.scope, filePath);
-  }
+  let filePath = `${fileName || profile.id}${EXTENSIONS.profile.source}`;
+  const versionStr = composeVersion(version);
   filePath = joinPath(basePath, filePath);
 
   const created = await OutputStream.writeIfAbsent(
     filePath,
     [
-      profileTemplate.header(profileName, version),
+      profileTemplate.header(profile.id, versionStr),
       ...usecaseNames.map(u => profileTemplate.empty(u)),
     ].join(''),
     { force: options?.force, dirs: true }
@@ -49,10 +42,10 @@ export async function createProfile(
 
   if (created) {
     options?.logCb?.(
-      `-> Created ${filePath} (name = "${profileName}", version = "${version}")`
+      `-> Created ${filePath} (name = "${profile.id}", version = "${versionStr}")`
     );
     if (superJson) {
-      superJson.mergeProfile(profileName, {
+      superJson.mergeProfile(profile.id, {
         file: relativePath(dirname(superJson.path), filePath),
       });
     }
@@ -65,35 +58,32 @@ export async function createProfile(
 export async function createMap(
   basePath: string,
   id: {
-    scope?: string;
-    name: string;
+    profile: ProfileId;
     provider: string;
     variant?: string;
     version: DocumentVersion;
   },
   usecaseNames: string[],
   superJson?: SuperJson,
+  fileName?: string,
   options?: {
     force?: boolean;
     logCb?: LogCallback;
   }
 ): Promise<void> {
-  let profileName = id.name;
   const variantName = id.variant ? `.${id.variant}` : '';
 
-  let filePath = `${profileName}.${id.provider}${variantName}${EXTENSIONS.map.source}`;
+  let filePath = `${
+    fileName || `${id.profile.id}.${id.provider}${variantName}`
+  }${EXTENSIONS.map.source}`;
   const version = composeVersion(id.version, true);
 
-  if (id.scope !== undefined) {
-    profileName = `${id.scope}/${profileName}`;
-    filePath = joinPath(id.scope, filePath);
-  }
   filePath = joinPath(basePath, filePath);
 
   const created = await OutputStream.writeIfAbsent(
     filePath,
     [
-      mapTemplate.header(profileName, id.provider, version, id.variant),
+      mapTemplate.header(id.profile.id, id.provider, version, id.variant),
       ...usecaseNames.map(u => mapTemplate.empty(u)),
     ].join(''),
     { force: options?.force, dirs: true }
@@ -101,10 +91,12 @@ export async function createMap(
 
   if (created) {
     options?.logCb?.(
-      `-> Created ${filePath} (profile = "${profileName}@${version}", provider = "${id.provider}")`
+      `-> Created ${filePath} (profile = "${id.profile.withVersion(
+        version
+      )}", provider = "${id.provider}")`
     );
     if (superJson) {
-      superJson.mergeProfileProvider(profileName, id.provider, {
+      superJson.mergeProfileProvider(id.profile.id, id.provider, {
         file: relativePath(dirname(superJson.path), filePath),
       });
     }
@@ -115,24 +107,28 @@ export async function createMap(
  */
 export async function createProviderJson(
   basePath: string,
-  name: string,
+  provider: string,
   superJson?: SuperJson,
+  fileName?: string,
   options?: {
     force?: boolean;
     logCb?: LogCallback;
   }
 ): Promise<void> {
-  const filePath = joinPath(basePath, `${name}.provider.json`);
+  const filePath = joinPath(
+    basePath,
+    fileName ? `${fileName}.json` : `${provider}.provider.json`
+  );
   const created = await OutputStream.writeIfAbsent(
     filePath,
-    providerTemplate.empty(name),
+    providerTemplate.empty(provider),
     { force: options?.force }
   );
 
   if (created) {
-    options?.logCb?.(`-> Created ${name}.provider.json`);
+    options?.logCb?.(`-> Created ${provider}.provider.json`);
     if (superJson) {
-      superJson.mergeProvider(name, {
+      superJson.mergeProvider(provider, {
         file: relativePath(dirname(superJson.path), filePath),
       });
     }
@@ -156,8 +152,15 @@ export async function create(
     version: DocumentVersion;
     variant?: string;
   },
-  superPath?: string,
-  basePath?: string,
+  paths: {
+    superPath?: string;
+    basePath?: string;
+  },
+  fileNames?: {
+    provider?: string;
+    map?: string;
+    profile?: string;
+  },
   options?: {
     logCb?: LogCallback;
     warnCb?: LogCallback;
@@ -165,8 +168,10 @@ export async function create(
 ): Promise<void> {
   //Load super json if we have path
   let superJson: SuperJson | undefined = undefined;
-  if (superPath) {
-    const loadedResult = await SuperJson.load(joinPath(superPath, META_FILE));
+  if (paths.superPath) {
+    const loadedResult = await SuperJson.load(
+      joinPath(paths.superPath, META_FILE)
+    );
     superJson = loadedResult.match(
       v => v,
       err => {
@@ -200,10 +205,16 @@ export async function create(
     }
     for (const provider of providers) {
       await createMap(
-        basePath ?? '',
-        { scope, name, provider, variant, version },
+        paths.basePath ?? '',
+        {
+          profile: ProfileId.fromScopeName(scope, name),
+          provider,
+          variant,
+          version,
+        },
         usecases,
         superJson,
+        fileNames?.map,
         { logCb: options?.logCb }
       );
     }
@@ -216,9 +227,15 @@ export async function create(
       );
     }
     for (const provider of providers) {
-      await createProviderJson(basePath ?? '', provider, superJson, {
-        logCb: options?.logCb,
-      });
+      await createProviderJson(
+        paths.basePath ?? '',
+        provider,
+        superJson,
+        fileNames?.provider,
+        {
+          logCb: options?.logCb,
+        }
+      );
     }
   }
   if (create.createProfile) {
@@ -229,10 +246,12 @@ export async function create(
       );
     }
     await createProfile(
-      basePath ?? '',
-      { scope, name, version },
+      paths.basePath ?? '',
+      ProfileId.fromScopeName(scope, name),
+      version,
       usecases,
       superJson,
+      fileNames?.profile,
       {
         logCb: options?.logCb,
       }

--- a/src/logic/init.test.ts
+++ b/src/logic/init.test.ts
@@ -103,7 +103,8 @@ describe('Init logic', () => {
       expect(createProfile).toHaveBeenNthCalledWith(
         1,
         'test/superface/grid',
-        ProfileId.fromScopeName(undefined, 'first-test-name'), { major: 1 },
+        ProfileId.fromScopeName(undefined, 'first-test-name'),
+        { major: 1 },
         [composeUsecaseName('first-test-name')],
         mockSuperJson,
         undefined,
@@ -112,7 +113,8 @@ describe('Init logic', () => {
       expect(createProfile).toHaveBeenNthCalledWith(
         2,
         'test/superface/grid',
-        ProfileId.fromScopeName(undefined, 'second-test-name'), { major: 2 },
+        ProfileId.fromScopeName(undefined, 'second-test-name'),
+        { major: 2 },
         [composeUsecaseName('second-test-name')],
         mockSuperJson,
         undefined,

--- a/src/logic/init.test.ts
+++ b/src/logic/init.test.ts
@@ -6,6 +6,7 @@ import { mocked } from 'ts-jest/utils';
 import { composeUsecaseName } from '../common/document';
 import { mkdir, mkdirQuiet } from '../common/io';
 import { OutputStream } from '../common/output-stream';
+import { ProfileId } from '../common/profile';
 import { createProfile } from './create';
 import { generateSpecifiedProfiles, initSuperface } from './init';
 
@@ -102,17 +103,19 @@ describe('Init logic', () => {
       expect(createProfile).toHaveBeenNthCalledWith(
         1,
         'test/superface/grid',
-        { scope: undefined, name: 'first-test-name', version: { major: 1 } },
+        ProfileId.fromScopeName(undefined, 'first-test-name'), { major: 1 },
         [composeUsecaseName('first-test-name')],
         mockSuperJson,
+        undefined,
         { logCb: undefined }
       );
       expect(createProfile).toHaveBeenNthCalledWith(
         2,
         'test/superface/grid',
-        { scope: undefined, name: 'second-test-name', version: { major: 2 } },
+        ProfileId.fromScopeName(undefined, 'second-test-name'), { major: 2 },
         [composeUsecaseName('second-test-name')],
         mockSuperJson,
+        undefined,
         { logCb: undefined }
       );
     });

--- a/src/logic/init.ts
+++ b/src/logic/init.ts
@@ -13,6 +13,7 @@ import { userError } from '../common/error';
 import { mkdir, mkdirQuiet } from '../common/io';
 import { formatShellLog, LogCallback } from '../common/log';
 import { OutputStream } from '../common/output-stream';
+import { ProfileId } from '../common/profile';
 import { createProfile } from './create';
 
 /**
@@ -115,9 +116,11 @@ export async function generateSpecifiedProfiles(
 
     await createProfile(
       joinPath(path, GRID_DIR),
-      { scope, name, version },
+      ProfileId.fromScopeName(scope, name),
+      version,
       [composeUsecaseName(name)],
       superJson,
+      undefined,
       { logCb }
     );
   }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR adds flags for specifying name of crated file when creating map/profile/provider


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This change is needed to enable CLI usage in Station.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
