### PR TITLE
fix: wrong path during map lint

### DIFF
--- a/src/commands/lint.integration.test.ts
+++ b/src/commands/lint.integration.test.ts
@@ -123,7 +123,7 @@ describe('lint CLI command', () => {
     expect(stdout.output).toContain(
       `❌ Parsing map file: ../../../../${fixture.invalidParsedMap}\n` +
         'SyntaxError: Expected `provider` but found `map`\n' +
-        ` --> ../../../../${fixture.strictProfile}:3:1\n` +
+        ` --> ../../../../${fixture.invalidParsedMap}:3:1\n` +
         '2 | \n' +
         '3 | map Foo {\n' +
         '  | ^^^      \n' +

--- a/src/logic/lint.ts
+++ b/src/logic/lint.ts
@@ -298,7 +298,7 @@ async function prepareLintedMap(
     };
 
     try {
-      mapAst = parseMap(new Source(mapSource, profile.path));
+      mapAst = parseMap(new Source(mapSource, map.path));
     } catch (e) {
       report.errors.push(e);
     }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR fixes wrong path passed to parser when lifting map.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
