### PR TITLE
chore: Use direct module import for configure.utils

### DIFF
--- a/src/logic/configure.utils.ts
+++ b/src/logic/configure.utils.ts
@@ -5,7 +5,11 @@ import {
   isBearerTokenSecurityScheme,
   isDigestSecurityScheme,
   SecurityScheme,
-} from '@superfaceai/one-sdk';
+  // Please use the exact path when importing the module from `@superfaceai/one-sdk`.
+  // This prevents from resolving top-level imports of other modules from SDK;
+  // and allows for easier bundling when using this module in other
+  // projects, e.g. frontend.
+} from '@superfaceai/one-sdk/dist/internal/providerjson';
 
 import { LogCallback } from '../common/log';
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

I'm proposing `configure.utils` module imports its used helper functions from OneSDK using the exact path to the direct module instead of resolving the module from the whole OneSDK package.


## Motivation and Context

This prevents from resolving top-level imports of other modules from OneSDK when importing the helper functions. 

It is important because OneSDK can be run only in Node environment (it uses APIs specific to Node) but we need `configure.utils` to be run in Web environments, too.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
