### PR TITLE
fix: do not throw on lint warning

### DIFF
--- a/src/commands/lint.test.ts
+++ b/src/commands/lint.test.ts
@@ -617,6 +617,147 @@ describe('lint CLI command', () => {
 
         expect(cleanupSpy).toHaveBeenCalledTimes(1);
       });
+
+      it('does not throw on warning', async () => {
+        const mockProfile = 'starwars/character-information';
+        const mockProvider = 'swapi';
+        const version = '1.0.2';
+        const mapVariant = 'test';
+        const mockSuperJson = new SuperJson({
+          profiles: {
+            [mockProfile]: {
+              version,
+              defaults: {},
+              providers: {
+                [mockProvider]: {
+                  mapVariant,
+                },
+              },
+            },
+          },
+          providers: {
+            [mockProvider]: {
+              file: '../swapi.provider.json',
+              security: [],
+            },
+          },
+        });
+        const loadSpy = jest
+          .spyOn(SuperJson, 'load')
+          .mockResolvedValue(ok(mockSuperJson));
+
+        mocked(detectSuperJson).mockResolvedValue('.');
+        mocked(lint).mockResolvedValue([[0, 1]]);
+        const writeSpy = jest
+          .spyOn(OutputStream.prototype, 'write')
+          .mockResolvedValue(undefined);
+        const cleanupSpy = jest
+          .spyOn(OutputStream.prototype, 'cleanup')
+          .mockResolvedValue(undefined);
+
+        await expect(
+          Lint.run([
+            '--profileId',
+            mockProfile,
+            '--providerName',
+            mockProvider,
+            '-s',
+            '4',
+          ])
+        ).resolves.toBeUndefined();
+
+        expect(lint).toHaveBeenCalledTimes(1);
+        expect(lint).toHaveBeenCalledWith(
+          mockSuperJson,
+          [
+            {
+              id: ProfileId.fromId(mockProfile),
+              maps: [{ provider: mockProvider, variant: mapVariant }],
+              version,
+            },
+          ],
+          expect.anything(),
+          expect.anything(),
+          { logCb: expect.anything(), errCb: expect.anything() }
+        );
+
+        expect(detectSuperJson).toHaveBeenCalledWith(process.cwd(), 4);
+        expect(loadSpy).toHaveBeenCalledTimes(1);
+        expect(writeSpy).toHaveBeenCalledTimes(1);
+        expect(writeSpy).toHaveBeenCalledWith(`\nDetected 1 problem\n`);
+
+        expect(cleanupSpy).toHaveBeenCalledTimes(1);
+      });
+      it('throws on error', async () => {
+        const mockProfile = 'starwars/character-information';
+        const mockProvider = 'swapi';
+        const version = '1.0.2';
+        const mapVariant = 'test';
+        const mockSuperJson = new SuperJson({
+          profiles: {
+            [mockProfile]: {
+              version,
+              defaults: {},
+              providers: {
+                [mockProvider]: {
+                  mapVariant,
+                },
+              },
+            },
+          },
+          providers: {
+            [mockProvider]: {
+              file: '../swapi.provider.json',
+              security: [],
+            },
+          },
+        });
+        const loadSpy = jest
+          .spyOn(SuperJson, 'load')
+          .mockResolvedValue(ok(mockSuperJson));
+
+        mocked(detectSuperJson).mockResolvedValue('.');
+        mocked(lint).mockResolvedValue([[1, 0]]);
+        const writeSpy = jest
+          .spyOn(OutputStream.prototype, 'write')
+          .mockResolvedValue(undefined);
+        const cleanupSpy = jest
+          .spyOn(OutputStream.prototype, 'cleanup')
+          .mockResolvedValue(undefined);
+
+        await expect(
+          Lint.run([
+            '--profileId',
+            mockProfile,
+            '--providerName',
+            mockProvider,
+            '-s',
+            '4',
+          ])
+        ).rejects.toEqual(new CLIError('❌ Errors were found'));
+
+        expect(lint).toHaveBeenCalledTimes(1);
+        expect(lint).toHaveBeenCalledWith(
+          mockSuperJson,
+          [
+            {
+              id: ProfileId.fromId(mockProfile),
+              maps: [{ provider: mockProvider, variant: mapVariant }],
+              version,
+            },
+          ],
+          expect.anything(),
+          expect.anything(),
+          { logCb: expect.anything(), errCb: expect.anything() }
+        );
+
+        expect(detectSuperJson).toHaveBeenCalledWith(process.cwd(), 4);
+        expect(loadSpy).toHaveBeenCalledTimes(1);
+        expect(writeSpy).toHaveBeenCalledTimes(1);
+        expect(writeSpy).toHaveBeenCalledWith(`\nDetected 1 problem\n`);
+
+        expect(cleanupSpy).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -212,7 +212,7 @@ export default class Lint extends Command {
     if (totals[0] > 0) {
       throw userError('❌ Errors were found', 1);
     } else if (totals[1] > 0) {
-      throw userError('❌ Warnings were found', 2);
+      this.logCallback?.('⚠️ Warnings were found');
     }
   }
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR removes throwing error on lint warning.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
