### PR TITLE
fix: print message only when there are some providers to configure

### DIFF
--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -205,6 +205,36 @@ describe('Install CLI command', () => {
       expect(installProfiles).toHaveBeenCalledTimes(0);
     }, 10000);
 
+    it('calls install profiles correctly - without providers', async () => {
+      mocked(detectSuperJson).mockResolvedValue('.');
+      const profileId = ProfileId.fromId('starwars/character-information');
+
+      await expect(
+        Install.run([profileId.id])
+      ).resolves.toBeUndefined();
+
+      expect(stdout.output).not.toContain('Configuring providers');
+      expect(installProfiles).toHaveBeenCalledTimes(1);
+      expect(installProfiles).toHaveBeenCalledWith({
+        superPath: '.',
+        requests: [
+          {
+            kind: 'store',
+            profileId: ProfileId.fromScopeName(
+              'starwars',
+              'character-information'
+            ),
+          },
+        ],
+        options: {
+          logCb: expect.anything(),
+          warnCb: expect.anything(),
+          tryToAuthenticate: true,
+          force: false,
+        },
+      });
+    }, 10000);
+
     it('calls install profiles correctly - one invalid provider', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
       mocked(installProvider).mockResolvedValue(undefined);
@@ -216,6 +246,7 @@ describe('Install CLI command', () => {
       ).resolves.toBeUndefined();
 
       expect(stdout.output).toContain('Invalid provider name: made.up');
+      expect(stdout.output).toContain('Configuring providers');
       expect(installProfiles).toHaveBeenCalledTimes(1);
       expect(installProfiles).toHaveBeenCalledWith({
         superPath: '.',

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -210,7 +210,9 @@ export default class Install extends Command {
       },
     });
 
-    this.logCallback?.(`\n\nConfiguring providers`);
+    if (providers.length > 0) {
+      this.logCallback?.(`\n\nConfiguring providers`);
+    }
     for (const provider of providers) {
       await installProvider({
         superPath,


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

This PR removes printing "Configuring providers" during install command when there are no providers to configure.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
