### PR TITLE
chore: unify user error output

### DIFF
--- a/src/commands/check.test.ts
+++ b/src/commands/check.test.ts
@@ -189,7 +189,7 @@ describe('Check CLI command', () => {
         ])
       ).rejects.toEqual(
         new CLIError(
-          '--scan/-s : Number of levels to scan cannot be higher than 5'
+          '❌ --scan/-s : Number of levels to scan cannot be higher than 5'
         )
       );
       expect(detectSuperJson).not.toHaveBeenCalled();

--- a/src/commands/check.test.ts
+++ b/src/commands/check.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { err, ok, SuperJson } from '@superfaceai/one-sdk';
 import { SDKExecutionError } from '@superfaceai/one-sdk/dist/internal/errors';
 import { mocked } from 'ts-jest/utils';
@@ -141,9 +140,7 @@ describe('Check CLI command', () => {
       mocked(detectSuperJson).mockResolvedValue(undefined);
       await expect(
         Check.run(['--profileId', profileId, '--providerName', provider])
-      ).rejects.toEqual(
-        new CLIError('❌ Unable to check, super.json not found')
-      );
+      ).rejects.toThrow('Unable to check, super.json not found');
     });
 
     it('throws when super.json not loaded correctly', async () => {
@@ -153,9 +150,7 @@ describe('Check CLI command', () => {
         .mockResolvedValue(err(new SDKExecutionError('test error', [], [])));
       await expect(
         Check.run(['--profileId', profileId, '--providerName', provider])
-      ).rejects.toEqual(
-        new CLIError('❌ Unable to load super.json: test error')
-      );
+      ).rejects.toThrow('Unable to load super.json: test error');
     });
 
     it('throws error on invalid scan flag', async () => {
@@ -169,9 +164,7 @@ describe('Check CLI command', () => {
           provider,
           '-s test',
         ])
-      ).rejects.toEqual(
-        new CLIError('Expected an integer but received:  test')
-      );
+      ).rejects.toThrow('Expected an integer but received:  test');
       expect(detectSuperJson).not.toHaveBeenCalled();
     }, 10000);
 
@@ -187,10 +180,8 @@ describe('Check CLI command', () => {
           '-s',
           '6',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          '❌ --scan/-s : Number of levels to scan cannot be higher than 5'
-        )
+      ).rejects.toThrow(
+        '--scan/-s : Number of levels to scan cannot be higher than 5'
       );
       expect(detectSuperJson).not.toHaveBeenCalled();
     }, 10000);
@@ -210,10 +201,8 @@ describe('Check CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          '❌ Invalid profile id: "U!0_" is not a valid lowercase identifier'
-        )
+      ).rejects.toThrow(
+        'Invalid profile id: "U!0_" is not a valid lowercase identifier'
       );
       expect(detectSuperJson).not.toHaveBeenCalled();
       expect(loadSpy).not.toHaveBeenCalled();
@@ -234,7 +223,7 @@ describe('Check CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(new CLIError('❌ Invalid provider name: "U!0_"'));
+      ).rejects.toThrow('Invalid provider name: "U!0_"');
       expect(detectSuperJson).not.toHaveBeenCalled();
       expect(loadSpy).not.toHaveBeenCalled();
     }, 10000);
@@ -247,10 +236,8 @@ describe('Check CLI command', () => {
 
       await expect(
         Check.run(['--providerName', provider, '-s', '3'])
-      ).rejects.toEqual(
-        new CLIError(
-          '❌ --profileId must be specified when using --providerName'
-        )
+      ).rejects.toThrow(
+        '--profileId must be specified when using --providerName'
       );
       expect(detectSuperJson).not.toHaveBeenCalled();
       expect(loadSpy).not.toHaveBeenCalled();
@@ -271,10 +258,8 @@ describe('Check CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Unable to check, profile: "${profileId}" not found in super.json`
-        )
+      ).rejects.toThrow(
+        `Unable to check, profile: "${profileId}" not found in super.json`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -302,10 +287,8 @@ describe('Check CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Unable to check, provider: "${provider}" not found in profile: "${profileId}" in super.json`
-        )
+      ).rejects.toThrow(
+        `Unable to check, provider: "${provider}" not found in profile: "${profileId}" in super.json`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -336,10 +319,8 @@ describe('Check CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Unable to check, provider: "${provider}" not found in super.json`
-        )
+      ).rejects.toThrow(
+        `Unable to check, provider: "${provider}" not found in super.json`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -375,9 +356,7 @@ describe('Check CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError('❌ Command found 4 errors and 4 warnings')
-      );
+      ).rejects.toThrow('Command found 4 errors and 4 warnings');
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
       expect(check).toHaveBeenCalledWith(
@@ -431,9 +410,7 @@ describe('Check CLI command', () => {
           '3',
           '-q',
         ])
-      ).rejects.toEqual(
-        new CLIError('❌ Command found 4 errors and 4 warnings')
-      );
+      ).rejects.toThrow('Command found 4 errors and 4 warnings');
 
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -491,9 +468,7 @@ describe('Check CLI command', () => {
           '-q',
           '-j',
         ])
-      ).rejects.toEqual(
-        new CLIError('❌ Command found 4 errors and 4 warnings')
-      );
+      ).rejects.toThrow('Command found 4 errors and 4 warnings');
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
       expect(check).toHaveBeenCalledWith(

--- a/src/commands/check.ts
+++ b/src/commands/check.ts
@@ -73,17 +73,17 @@ export default class Check extends Command {
     if (flags.profileId) {
       const parsedProfileId = parseDocumentId(flags.profileId);
       if (parsedProfileId.kind == 'error') {
-        throw userError(`❌ Invalid profile id: ${parsedProfileId.message}`, 1);
+        throw userError(`Invalid profile id: ${parsedProfileId.message}`, 1);
       }
     }
 
     if (flags.providerName) {
       if (!isValidProviderName(flags.providerName)) {
-        throw userError(`❌ Invalid provider name: "${flags.providerName}"`, 1);
+        throw userError(`Invalid provider name: "${flags.providerName}"`, 1);
       }
       if (!flags.profileId) {
         throw userError(
-          `❌ --profileId must be specified when using --providerName`,
+          `--profileId must be specified when using --providerName`,
           1
         );
       }
@@ -98,16 +98,13 @@ export default class Check extends Command {
     //Load super json
     const superPath = await detectSuperJson(process.cwd(), flags.scan);
     if (!superPath) {
-      throw userError('❌ Unable to check, super.json not found', 1);
+      throw userError('Unable to check, super.json not found', 1);
     }
     const loadedResult = await SuperJson.load(joinPath(superPath, META_FILE));
     const superJson = loadedResult.match(
       v => v,
       err => {
-        throw userError(
-          `❌ Unable to load super.json: ${err.formatShort()}`,
-          1
-        );
+        throw userError(`Unable to load super.json: ${err.formatShort()}`, 1);
       }
     );
 
@@ -115,7 +112,7 @@ export default class Check extends Command {
     if (flags.profileId) {
       if (!superJson.normalized.profiles[flags.profileId]) {
         throw userError(
-          `❌ Unable to check, profile: "${flags.profileId}" not found in super.json`,
+          `Unable to check, profile: "${flags.profileId}" not found in super.json`,
           1
         );
       }
@@ -126,13 +123,13 @@ export default class Check extends Command {
           ]
         ) {
           throw userError(
-            `❌ Unable to check, provider: "${flags.providerName}" not found in profile: "${flags.profileId}" in super.json`,
+            `Unable to check, provider: "${flags.providerName}" not found in profile: "${flags.profileId}" in super.json`,
             1
           );
         }
         if (!superJson.normalized.providers[flags.providerName]) {
           throw userError(
-            `❌ Unable to check, provider: "${flags.providerName}" not found in super.json`,
+            `Unable to check, provider: "${flags.providerName}" not found in super.json`,
             1
           );
         }
@@ -159,7 +156,7 @@ export default class Check extends Command {
     const numOfWarnings = issues.filter(issue => issue.kind === 'warn').length;
     if (numOfErrros > 0 || (flags.failOnWarning && numOfWarnings > 0)) {
       throw userError(
-        `❌ Command found ${numOfErrros} errors and ${numOfWarnings} warnings`,
+        `Command found ${numOfErrros} errors and ${numOfWarnings} warnings`,
         1
       );
     }

--- a/src/commands/compile.test.ts
+++ b/src/commands/compile.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { err, ok, SuperJson } from '@superfaceai/one-sdk';
 import { SDKExecutionError } from '@superfaceai/one-sdk/dist/internal/errors';
 import { mocked } from 'ts-jest/utils';
@@ -79,8 +78,8 @@ describe('Compile CLI command', () => {
     });
     it('throws when super.json not found', async () => {
       mocked(detectSuperJson).mockResolvedValue(undefined);
-      await expect(Compile.run([])).rejects.toEqual(
-        new CLIError('❌ Unable to compile, super.json not found')
+      await expect(Compile.run([])).rejects.toThrow(
+        'Unable to compile, super.json not found'
       );
     });
 
@@ -89,16 +88,16 @@ describe('Compile CLI command', () => {
       jest
         .spyOn(SuperJson, 'load')
         .mockResolvedValue(err(new SDKExecutionError('test error', [], [])));
-      await expect(Compile.run([])).rejects.toEqual(
-        new CLIError('❌ Unable to load super.json: test error')
+      await expect(Compile.run([])).rejects.toThrow(
+        'Unable to load super.json: test error'
       );
     });
 
     it('throws error on invalid scan flag', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
 
-      await expect(Compile.run(['-s test'])).rejects.toEqual(
-        new CLIError('Expected an integer but received:  test')
+      await expect(Compile.run(['-s test'])).rejects.toThrow(
+        'Expected an integer but received:  test'
       );
       expect(detectSuperJson).not.toHaveBeenCalled();
     }, 10000);
@@ -106,10 +105,8 @@ describe('Compile CLI command', () => {
     it('throws error on scan flag higher than 5', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
 
-      await expect(Compile.run(['-s', '6'])).rejects.toEqual(
-        new CLIError(
-          '❌ --scan/-s : Number of levels to scan cannot be higher than 5'
-        )
+      await expect(Compile.run(['-s', '6'])).rejects.toThrow(
+        '--scan/-s : Number of levels to scan cannot be higher than 5'
       );
       expect(detectSuperJson).not.toHaveBeenCalled();
     }, 10000);
@@ -129,10 +126,8 @@ describe('Compile CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          '❌ Invalid profile id: "U!0_" is not a valid lowercase identifier'
-        )
+      ).rejects.toThrow(
+        '❌ Invalid profile id: "U!0_" is not a valid lowercase identifier'
       );
       expect(detectSuperJson).not.toHaveBeenCalled();
       expect(loadSpy).not.toHaveBeenCalled();
@@ -153,7 +148,7 @@ describe('Compile CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(new CLIError('❌ Invalid provider name: "U!0_"'));
+      ).rejects.toThrow('Invalid provider name: "U!0_"');
       expect(detectSuperJson).not.toHaveBeenCalled();
       expect(loadSpy).not.toHaveBeenCalled();
     }, 10000);
@@ -166,10 +161,8 @@ describe('Compile CLI command', () => {
 
       await expect(
         Compile.run(['--providerName', mockProvider, '-s', '3'])
-      ).rejects.toEqual(
-        new CLIError(
-          '❌ --profileId must be specified when using --providerName'
-        )
+      ).rejects.toThrow(
+        '--profileId must be specified when using --providerName'
       );
       expect(detectSuperJson).not.toHaveBeenCalled();
       expect(loadSpy).not.toHaveBeenCalled();
@@ -190,10 +183,8 @@ describe('Compile CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Unable to compile, profile: "${mockProfile}" not found in super.json`
-        )
+      ).rejects.toThrow(
+        `❌ Unable to compile, profile: "${mockProfile}" not found in super.json`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -224,10 +215,8 @@ describe('Compile CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Unable to compile, provider: "${mockProvider}" not found in profile: "${mockProfile}" in super.json`
-        )
+      ).rejects.toThrow(
+        `Unable to compile, provider: "${mockProvider}" not found in profile: "${mockProfile}" in super.json`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -71,17 +71,17 @@ export default class Compile extends Command {
     if (flags.profileId) {
       const parsedProfileId = parseDocumentId(flags.profileId);
       if (parsedProfileId.kind == 'error') {
-        throw userError(`❌ Invalid profile id: ${parsedProfileId.message}`, 1);
+        throw userError(`Invalid profile id: ${parsedProfileId.message}`, 1);
       }
     }
 
     if (flags.providerName) {
       if (!isValidProviderName(flags.providerName)) {
-        throw userError(`❌ Invalid provider name: "${flags.providerName}"`, 1);
+        throw userError(`Invalid provider name: "${flags.providerName}"`, 1);
       }
       if (!flags.profileId) {
         throw userError(
-          `❌ --profileId must be specified when using --providerName`,
+          `--profileId must be specified when using --providerName`,
           1
         );
       }
@@ -89,24 +89,21 @@ export default class Compile extends Command {
 
     if (flags.scan && (typeof flags.scan !== 'number' || flags.scan > 5)) {
       throw userError(
-        '❌ --scan/-s : Number of levels to scan cannot be higher than 5',
+        '--scan/-s : Number of levels to scan cannot be higher than 5',
         1
       );
     }
 
     const superPath = await detectSuperJson(process.cwd(), flags.scan);
     if (!superPath) {
-      throw userError('❌ Unable to compile, super.json not found', 1);
+      throw userError('Unable to compile, super.json not found', 1);
     }
     //Load super json
     const loadedResult = await SuperJson.load(joinPath(superPath, META_FILE));
     const superJson = loadedResult.match(
       v => v,
       err => {
-        throw userError(
-          `❌ Unable to load super.json: ${err.formatShort()}`,
-          1
-        );
+        throw userError(`Unable to load super.json: ${err.formatShort()}`, 1);
       }
     );
 
@@ -114,7 +111,7 @@ export default class Compile extends Command {
     if (flags.profileId) {
       if (!superJson.normalized.profiles[flags.profileId]) {
         throw userError(
-          `❌ Unable to compile, profile: "${flags.profileId}" not found in super.json`,
+          `Unable to compile, profile: "${flags.profileId}" not found in super.json`,
           1
         );
       }
@@ -125,7 +122,7 @@ export default class Compile extends Command {
           ]
         ) {
           throw userError(
-            `❌ Unable to compile, provider: "${flags.providerName}" not found in profile: "${flags.profileId}" in super.json`,
+            `Unable to compile, provider: "${flags.providerName}" not found in profile: "${flags.profileId}" in super.json`,
             1
           );
         }

--- a/src/commands/configure.integration.test.ts
+++ b/src/commands/configure.integration.test.ts
@@ -531,7 +531,9 @@ describe('Configure CLI command', () => {
           mockServer.url
         )
       ).rejects.toEqual(
-        expect.stringContaining('Error: Local path: "some/path" does not exist')
+        expect.stringContaining(
+          'Error: ❌ Local path: "some/path" does not exist'
+        )
       );
 
       const finalSuperJson = (

--- a/src/commands/configure.test.ts
+++ b/src/commands/configure.test.ts
@@ -49,7 +49,7 @@ describe('Configure CLI command', () => {
     it('does not configure on invalid provider name', async () => {
       mocked(isValidDocumentName).mockReturnValue(false);
       await expect(Configure.run(['U7!O', '-p', 'test'])).rejects.toEqual(
-        new CLIError('Invalid provider name')
+        new CLIError('❌ Invalid provider name')
       );
 
       expect(detectSuperJson).not.toHaveBeenCalled();
@@ -61,7 +61,9 @@ describe('Configure CLI command', () => {
       mocked(exists).mockResolvedValue(false);
       await expect(
         Configure.run(['swapi', '-p', 'test', '--localMap', 'some/path'])
-      ).rejects.toEqual(new CLIError('Local path: "some/path" does not exist'));
+      ).rejects.toEqual(
+        new CLIError('❌ Local path: "some/path" does not exist')
+      );
 
       expect(detectSuperJson).not.toHaveBeenCalled();
       expect(installProvider).not.toHaveBeenCalled();
@@ -72,7 +74,9 @@ describe('Configure CLI command', () => {
       mocked(exists).mockResolvedValue(false);
       await expect(
         Configure.run(['swapi', '-p', 'test', '--localProvider', 'some/path'])
-      ).rejects.toEqual(new CLIError('Local path: "some/path" does not exist'));
+      ).rejects.toEqual(
+        new CLIError('❌ Local path: "some/path" does not exist')
+      );
 
       expect(detectSuperJson).not.toHaveBeenCalled();
       expect(installProvider).not.toHaveBeenCalled();

--- a/src/commands/configure.test.ts
+++ b/src/commands/configure.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { isValidDocumentName } from '@superfaceai/ast';
 import { SuperJson } from '@superfaceai/one-sdk';
 import { mocked } from 'ts-jest/utils';
@@ -48,8 +47,8 @@ describe('Configure CLI command', () => {
 
     it('does not configure on invalid provider name', async () => {
       mocked(isValidDocumentName).mockReturnValue(false);
-      await expect(Configure.run(['U7!O', '-p', 'test'])).rejects.toEqual(
-        new CLIError('❌ Invalid provider name')
+      await expect(Configure.run(['U7!O', '-p', 'test'])).rejects.toThrow(
+        'Invalid provider name'
       );
 
       expect(detectSuperJson).not.toHaveBeenCalled();
@@ -61,9 +60,7 @@ describe('Configure CLI command', () => {
       mocked(exists).mockResolvedValue(false);
       await expect(
         Configure.run(['swapi', '-p', 'test', '--localMap', 'some/path'])
-      ).rejects.toEqual(
-        new CLIError('❌ Local path: "some/path" does not exist')
-      );
+      ).rejects.toThrow('Local path: "some/path" does not exist');
 
       expect(detectSuperJson).not.toHaveBeenCalled();
       expect(installProvider).not.toHaveBeenCalled();
@@ -74,9 +71,7 @@ describe('Configure CLI command', () => {
       mocked(exists).mockResolvedValue(false);
       await expect(
         Configure.run(['swapi', '-p', 'test', '--localProvider', 'some/path'])
-      ).rejects.toEqual(
-        new CLIError('❌ Local path: "some/path" does not exist')
-      );
+      ).rejects.toThrow('Local path: "some/path" does not exist');
 
       expect(detectSuperJson).not.toHaveBeenCalled();
       expect(installProvider).not.toHaveBeenCalled();

--- a/src/commands/create.test.ts
+++ b/src/commands/create.test.ts
@@ -1111,7 +1111,7 @@ describe('Create CLI command', () => {
         ])
       ).rejects.toEqual(
         new CLIError(
-          'Unable to create mutiple providers with same file name: "test"'
+          '❌ Unable to create mutiple providers with same file name: "test"'
         )
       );
 
@@ -1143,7 +1143,7 @@ describe('Create CLI command', () => {
         ])
       ).rejects.toEqual(
         new CLIError(
-          'Unable to create mutiple maps with same file name: "test"'
+          '❌ Unable to create mutiple maps with same file name: "test"'
         )
       );
 
@@ -1154,24 +1154,24 @@ describe('Create CLI command', () => {
     it('throws error on invalid document name', async () => {
       await expect(
         Create.run(['--profileId', 'map', '--profile'])
-      ).rejects.toEqual(new CLIError('ProfileId is reserved!'));
+      ).rejects.toEqual(new CLIError('❌ ProfileId is reserved!'));
 
       await expect(
         Create.run(['--profileId', 'profile', '--profile'])
-      ).rejects.toEqual(new CLIError('ProfileId is reserved!'));
+      ).rejects.toEqual(new CLIError('❌ ProfileId is reserved!'));
 
       await expect(
         Create.run(['--providerName', 'map', '--provider'])
-      ).rejects.toEqual(new CLIError('ProviderName "map" is reserved!'));
+      ).rejects.toEqual(new CLIError('❌ ProviderName "map" is reserved!'));
 
       await expect(
         Create.run(['--providerName', 'profile', '--provider'])
-      ).rejects.toEqual(new CLIError('ProviderName "profile" is reserved!'));
+      ).rejects.toEqual(new CLIError('❌ ProviderName "profile" is reserved!'));
     });
 
     it('throws error on missing profileId and providerNamse', async () => {
       await expect(Create.run([])).rejects.toEqual(
-        new CLIError('Invalid command! Specify profileId or providerName')
+        new CLIError('❌ Invalid command! Specify profileId or providerName')
       );
     });
 
@@ -1186,7 +1186,7 @@ describe('Create CLI command', () => {
           '-t',
           'vT_7!',
         ])
-      ).rejects.toEqual(new CLIError('Invalid map variant: vT_7!'));
+      ).rejects.toEqual(new CLIError('❌ Invalid map variant: vT_7!'));
     });
 
     it('throws error on invalid provider name', async () => {
@@ -1198,7 +1198,7 @@ describe('Create CLI command', () => {
           'vT_7!',
           '--map',
         ])
-      ).rejects.toEqual(new CLIError('Invalid provider name: vT_7!'));
+      ).rejects.toEqual(new CLIError('❌ Invalid provider name: vT_7!'));
     });
 
     it('throws error on invalid document', async () => {
@@ -1209,7 +1209,7 @@ describe('Create CLI command', () => {
       await expect(
         Create.run(['--profileId', documentName, '-u', 'SendSMS', '--profile'])
       ).rejects.toEqual(
-        new CLIError('"vT_7!" is not a valid lowercase identifier')
+        new CLIError('❌ "vT_7!" is not a valid lowercase identifier')
       );
     });
 
@@ -1228,7 +1228,7 @@ describe('Create CLI command', () => {
           'SendSMS',
           '--profile',
         ])
-      ).rejects.toEqual(new CLIError(' is not a valid version'));
+      ).rejects.toEqual(new CLIError('❌  is not a valid version'));
     });
 
     it('throws error on invalid usecase', async () => {
@@ -1238,7 +1238,7 @@ describe('Create CLI command', () => {
 
       await expect(
         Create.run(['--profileId', documentName, '-u', '7_L§', '--profile'])
-      ).rejects.toEqual(new CLIError('Invalid usecase name: 7_L§'));
+      ).rejects.toEqual(new CLIError('❌ Invalid usecase name: 7_L§'));
     });
   });
 });

--- a/src/commands/create.test.ts
+++ b/src/commands/create.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { SuperJson } from '@superfaceai/one-sdk';
 import inquirer from 'inquirer';
 import { mocked } from 'ts-jest/utils';
@@ -1109,10 +1108,8 @@ describe('Create CLI command', () => {
           '--providerFileName',
           'test',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          '❌ Unable to create mutiple providers with same file name: "test"'
-        )
+      ).rejects.toThrow(
+        'Unable to create mutiple providers with same file name: "test"'
       );
 
       expect(create).not.toHaveBeenCalled();
@@ -1141,10 +1138,8 @@ describe('Create CLI command', () => {
           '--mapFileName',
           'test',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          '❌ Unable to create mutiple maps with same file name: "test"'
-        )
+      ).rejects.toThrow(
+        'Unable to create mutiple maps with same file name: "test"'
       );
 
       expect(create).not.toHaveBeenCalled();
@@ -1154,24 +1149,24 @@ describe('Create CLI command', () => {
     it('throws error on invalid document name', async () => {
       await expect(
         Create.run(['--profileId', 'map', '--profile'])
-      ).rejects.toEqual(new CLIError('❌ ProfileId is reserved!'));
+      ).rejects.toThrow('ProfileId is reserved!');
 
       await expect(
         Create.run(['--profileId', 'profile', '--profile'])
-      ).rejects.toEqual(new CLIError('❌ ProfileId is reserved!'));
+      ).rejects.toThrow('ProfileId is reserved!');
 
       await expect(
         Create.run(['--providerName', 'map', '--provider'])
-      ).rejects.toEqual(new CLIError('❌ ProviderName "map" is reserved!'));
+      ).rejects.toThrow('ProviderName "map" is reserved!');
 
       await expect(
         Create.run(['--providerName', 'profile', '--provider'])
-      ).rejects.toEqual(new CLIError('❌ ProviderName "profile" is reserved!'));
+      ).rejects.toThrow('ProviderName "profile" is reserved!');
     });
 
     it('throws error on missing profileId and providerNamse', async () => {
-      await expect(Create.run([])).rejects.toEqual(
-        new CLIError('❌ Invalid command! Specify profileId or providerName')
+      await expect(Create.run([])).rejects.toThrow(
+        'Invalid command! Specify profileId or providerName'
       );
     });
 
@@ -1186,7 +1181,7 @@ describe('Create CLI command', () => {
           '-t',
           'vT_7!',
         ])
-      ).rejects.toEqual(new CLIError('❌ Invalid map variant: vT_7!'));
+      ).rejects.toThrow('Invalid map variant: vT_7!');
     });
 
     it('throws error on invalid provider name', async () => {
@@ -1198,7 +1193,7 @@ describe('Create CLI command', () => {
           'vT_7!',
           '--map',
         ])
-      ).rejects.toEqual(new CLIError('❌ Invalid provider name: vT_7!'));
+      ).rejects.toThrow('Invalid provider name: vT_7!');
     });
 
     it('throws error on invalid document', async () => {
@@ -1208,9 +1203,7 @@ describe('Create CLI command', () => {
 
       await expect(
         Create.run(['--profileId', documentName, '-u', 'SendSMS', '--profile'])
-      ).rejects.toEqual(
-        new CLIError('❌ "vT_7!" is not a valid lowercase identifier')
-      );
+      ).rejects.toThrow('"vT_7!" is not a valid lowercase identifier');
     });
 
     it('throws error on invalid version', async () => {
@@ -1228,7 +1221,7 @@ describe('Create CLI command', () => {
           'SendSMS',
           '--profile',
         ])
-      ).rejects.toEqual(new CLIError('❌  is not a valid version'));
+      ).rejects.toThrow('is not a valid version');
     });
 
     it('throws error on invalid usecase', async () => {
@@ -1238,7 +1231,7 @@ describe('Create CLI command', () => {
 
       await expect(
         Create.run(['--profileId', documentName, '-u', '7_L§', '--profile'])
-      ).rejects.toEqual(new CLIError('❌ Invalid usecase name: 7_L§'));
+      ).rejects.toThrow('Invalid usecase name: 7_L§');
     });
   });
 });

--- a/src/commands/generate.test.ts
+++ b/src/commands/generate.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { err, ok, SuperJson } from '@superfaceai/one-sdk';
 import { SDKExecutionError } from '@superfaceai/one-sdk/dist/internal/errors';
 import { mocked } from 'ts-jest/utils';
@@ -44,8 +43,8 @@ describe('Generate CLI command', () => {
   describe('when running generate command', () => {
     it('throws when super.json not found', async () => {
       mocked(detectSuperJson).mockResolvedValue(undefined);
-      await expect(Generate.run(['--profileId', profileId])).rejects.toEqual(
-        new CLIError('❌ Unable to generate, super.json not found')
+      await expect(Generate.run(['--profileId', profileId])).rejects.toThrow(
+        'Unable to generate, super.json not found'
       );
     });
 
@@ -54,16 +53,16 @@ describe('Generate CLI command', () => {
       jest
         .spyOn(SuperJson, 'load')
         .mockResolvedValue(err(new SDKExecutionError('test error', [], [])));
-      await expect(Generate.run(['--profileId', profileId])).rejects.toEqual(
-        new CLIError('❌ Unable to load super.json: test error')
+      await expect(Generate.run(['--profileId', profileId])).rejects.toThrow(
+        'Unable to load super.json: test error'
       );
     });
 
     it('throws error on invalid scan flag', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
 
-      await expect(Generate.run(['-s test'])).rejects.toEqual(
-        new CLIError('Expected an integer but received:  test')
+      await expect(Generate.run(['-s test'])).rejects.toThrow(
+        'Expected an integer but received:  test'
       );
       expect(detectSuperJson).not.toHaveBeenCalled();
     }, 10000);
@@ -73,10 +72,8 @@ describe('Generate CLI command', () => {
 
       await expect(
         Generate.run(['--profileId', profileId, '-s', '6'])
-      ).rejects.toEqual(
-        new CLIError(
-          '❌ --scan/-s : Number of levels to scan cannot be higher than 5'
-        )
+      ).rejects.toThrow(
+        '--scan/-s : Number of levels to scan cannot be higher than 5'
       );
       expect(detectSuperJson).not.toHaveBeenCalled();
     }, 10000);
@@ -89,10 +86,8 @@ describe('Generate CLI command', () => {
 
       await expect(
         Generate.run(['--profileId', 'U!0_', '-s', '3'])
-      ).rejects.toEqual(
-        new CLIError(
-          '❌ Invalid profile id: "U!0_" is not a valid lowercase identifier'
-        )
+      ).rejects.toThrow(
+        'Invalid profile id: "U!0_" is not a valid lowercase identifier'
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -106,9 +101,7 @@ describe('Generate CLI command', () => {
 
       await expect(
         Generate.run(['--profileId', profileId, '-s', '3'])
-      ).rejects.toEqual(
-        new CLIError(`❌ Profile id: "${profileId}" not found in super.json`)
-      );
+      ).rejects.toThrow(`Profile id: "${profileId}" not found in super.json`);
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
     }, 10000);

--- a/src/commands/generate.test.ts
+++ b/src/commands/generate.test.ts
@@ -45,7 +45,7 @@ describe('Generate CLI command', () => {
     it('throws when super.json not found', async () => {
       mocked(detectSuperJson).mockResolvedValue(undefined);
       await expect(Generate.run(['--profileId', profileId])).rejects.toEqual(
-        new CLIError('Unable to generate, super.json not found')
+        new CLIError('❌ Unable to generate, super.json not found')
       );
     });
 
@@ -55,7 +55,7 @@ describe('Generate CLI command', () => {
         .spyOn(SuperJson, 'load')
         .mockResolvedValue(err(new SDKExecutionError('test error', [], [])));
       await expect(Generate.run(['--profileId', profileId])).rejects.toEqual(
-        new CLIError('Unable to load super.json: test error')
+        new CLIError('❌ Unable to load super.json: test error')
       );
     });
 
@@ -75,7 +75,7 @@ describe('Generate CLI command', () => {
         Generate.run(['--profileId', profileId, '-s', '6'])
       ).rejects.toEqual(
         new CLIError(
-          '--scan/-s : Number of levels to scan cannot be higher than 5'
+          '❌ --scan/-s : Number of levels to scan cannot be higher than 5'
         )
       );
       expect(detectSuperJson).not.toHaveBeenCalled();
@@ -91,7 +91,7 @@ describe('Generate CLI command', () => {
         Generate.run(['--profileId', 'U!0_', '-s', '3'])
       ).rejects.toEqual(
         new CLIError(
-          'Invalid profile id: "U!0_" is not a valid lowercase identifier'
+          '❌ Invalid profile id: "U!0_" is not a valid lowercase identifier'
         )
       );
       expect(detectSuperJson).toHaveBeenCalled();
@@ -107,7 +107,7 @@ describe('Generate CLI command', () => {
       await expect(
         Generate.run(['--profileId', profileId, '-s', '3'])
       ).rejects.toEqual(
-        new CLIError(`Profile id: "${profileId}" not found in super.json`)
+        new CLIError(`❌ Profile id: "${profileId}" not found in super.json`)
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { SuperJson } from '@superfaceai/one-sdk';
 import { mocked } from 'ts-jest/utils';
 
@@ -151,9 +150,10 @@ describe('Install CLI command', () => {
     it('throws error on empty profileId argument with providers flag', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
 
-      await expect(Install.run(['--providers', 'twilio'])).rejects.toEqual(
-        new CLIError('EEXIT: 0')
+      await expect(Install.run(['--providers', 'twilio'])).rejects.toThrow(
+        'EEXIT: 0'
       );
+
       expect(installProfiles).not.toHaveBeenCalled();
     }, 10000);
 
@@ -177,8 +177,8 @@ describe('Install CLI command', () => {
       mocked(detectSuperJson).mockResolvedValue('.');
       const profileName = 'starwars/character-information';
 
-      await expect(Install.run([profileName, '-p'])).rejects.toEqual(
-        new CLIError('Flag --providers expects a value')
+      await expect(Install.run([profileName, '-p'])).rejects.toThrow(
+        'Flag --providers expects a value'
       );
       expect(installProfiles).toHaveBeenCalledTimes(0);
     }, 10000);
@@ -187,8 +187,8 @@ describe('Install CLI command', () => {
       mocked(detectSuperJson).mockResolvedValue('.');
       const profileName = 'starwars/character-information';
 
-      await expect(Install.run([profileName, '-s test'])).rejects.toEqual(
-        new CLIError('Expected an integer but received:  test')
+      await expect(Install.run([profileName, '-s test'])).rejects.toThrow(
+        'Expected an integer but received:  test'
       );
       expect(installProfiles).toHaveBeenCalledTimes(0);
     }, 10000);
@@ -197,10 +197,8 @@ describe('Install CLI command', () => {
       mocked(detectSuperJson).mockResolvedValue('.');
       const profileName = 'starwars/character-information';
 
-      await expect(Install.run([profileName, '-s', '6'])).rejects.toEqual(
-        new CLIError(
-          '❌ --scan/-s : Number of levels to scan cannot be higher than 5'
-        )
+      await expect(Install.run([profileName, '-s', '6'])).rejects.toThrow(
+        '--scan/-s : Number of levels to scan cannot be higher than 5'
       );
       expect(installProfiles).toHaveBeenCalledTimes(0);
     }, 10000);

--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -199,7 +199,7 @@ describe('Install CLI command', () => {
 
       await expect(Install.run([profileName, '-s', '6'])).rejects.toEqual(
         new CLIError(
-          '--scan/-s : Number of levels to scan cannot be higher than 5'
+          '❌ --scan/-s : Number of levels to scan cannot be higher than 5'
         )
       );
       expect(installProfiles).toHaveBeenCalledTimes(0);

--- a/src/commands/interactive.create.test.ts
+++ b/src/commands/interactive.create.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { SuperJson } from '@superfaceai/one-sdk';
 import inquirer from 'inquirer';
 import { mocked } from 'ts-jest/utils';
@@ -500,27 +499,27 @@ describe('Interactive create CLI command', () => {
     });
 
     it('throws error on invalid command', async () => {
-      await expect(Create.run([])).rejects.toEqual(
-        new CLIError('❌ Invalid command! Specify profileId or providerName')
+      await expect(Create.run([])).rejects.toThrow(
+        'Invalid command! Specify profileId or providerName'
       );
     });
 
     it('throws error on invalid document name', async () => {
       await expect(
         Create.run(['--profileId', 'map', '--profile'])
-      ).rejects.toEqual(new CLIError('❌ ProfileId is reserved!'));
+      ).rejects.toThrow('ProfileId is reserved!');
 
       await expect(
         Create.run(['--profileId', 'profile', '--profile'])
-      ).rejects.toEqual(new CLIError('❌ ProfileId is reserved!'));
+      ).rejects.toThrow('ProfileId is reserved!');
 
       await expect(
         Create.run(['--providerName', 'map', '--provider'])
-      ).rejects.toEqual(new CLIError('❌ ProviderName "map" is reserved!'));
+      ).rejects.toThrow('ProviderName "map" is reserved!');
 
       await expect(
         Create.run(['--providerName', 'profile', '--provider'])
-      ).rejects.toEqual(new CLIError('❌ ProviderName "profile" is reserved!'));
+      ).rejects.toThrow('ProviderName "profile" is reserved!');
     });
 
     it('throws error on invalid variant', async () => {
@@ -540,7 +539,7 @@ describe('Interactive create CLI command', () => {
           '--profile',
           '--map',
         ])
-      ).rejects.toEqual(new CLIError('❌ Invalid map variant: vT_7!'));
+      ).rejects.toThrow('Invalid map variant: vT_7!');
     });
 
     it('throws error on invalid provider name', async () => {
@@ -559,8 +558,8 @@ describe('Interactive create CLI command', () => {
         //Init
         .mockResolvedValueOnce({ init: true });
 
-      await expect(Create.run(['-i'])).rejects.toEqual(
-        new CLIError('❌ Invalid provider name: vT_7!')
+      await expect(Create.run(['-i'])).rejects.toThrow(
+        'Invalid provider name: vT_7!'
       );
     });
 
@@ -581,8 +580,8 @@ describe('Interactive create CLI command', () => {
         .mockResolvedValueOnce({ input: 'twilio' })
         //Init
         .mockResolvedValueOnce({ init: true });
-      await expect(Create.run(['-u', 'SendSMS', '-i'])).rejects.toEqual(
-        new CLIError('❌ "vT_7!" is not a valid lowercase identifier')
+      await expect(Create.run(['-u', 'SendSMS', '-i'])).rejects.toThrow(
+        '"vT_7!" is not a valid lowercase identifier'
       );
     });
 
@@ -606,7 +605,7 @@ describe('Interactive create CLI command', () => {
 
       await expect(
         Create.run(['-v', '', '-u', 'SendSMS', '-i'])
-      ).rejects.toEqual(new CLIError('❌  is not a valid version'));
+      ).rejects.toThrow(' is not a valid version');
     });
 
     it('throws error on invalid usecase', async () => {
@@ -627,8 +626,8 @@ describe('Interactive create CLI command', () => {
         //Init
         .mockResolvedValueOnce({ init: true });
 
-      await expect(Create.run(['-u', '7_L§', '-i'])).rejects.toEqual(
-        new CLIError('❌ Invalid usecase name: 7_L§')
+      await expect(Create.run(['-u', '7_L§', '-i'])).rejects.toThrow(
+        'Invalid usecase name: 7_L§'
       );
     });
   });

--- a/src/commands/interactive.create.test.ts
+++ b/src/commands/interactive.create.test.ts
@@ -501,26 +501,26 @@ describe('Interactive create CLI command', () => {
 
     it('throws error on invalid command', async () => {
       await expect(Create.run([])).rejects.toEqual(
-        new CLIError('Invalid command! Specify profileId or providerName')
+        new CLIError('❌ Invalid command! Specify profileId or providerName')
       );
     });
 
     it('throws error on invalid document name', async () => {
       await expect(
         Create.run(['--profileId', 'map', '--profile'])
-      ).rejects.toEqual(new CLIError('ProfileId is reserved!'));
+      ).rejects.toEqual(new CLIError('❌ ProfileId is reserved!'));
 
       await expect(
         Create.run(['--profileId', 'profile', '--profile'])
-      ).rejects.toEqual(new CLIError('ProfileId is reserved!'));
+      ).rejects.toEqual(new CLIError('❌ ProfileId is reserved!'));
 
       await expect(
         Create.run(['--providerName', 'map', '--provider'])
-      ).rejects.toEqual(new CLIError('ProviderName "map" is reserved!'));
+      ).rejects.toEqual(new CLIError('❌ ProviderName "map" is reserved!'));
 
       await expect(
         Create.run(['--providerName', 'profile', '--provider'])
-      ).rejects.toEqual(new CLIError('ProviderName "profile" is reserved!'));
+      ).rejects.toEqual(new CLIError('❌ ProviderName "profile" is reserved!'));
     });
 
     it('throws error on invalid variant', async () => {
@@ -540,7 +540,7 @@ describe('Interactive create CLI command', () => {
           '--profile',
           '--map',
         ])
-      ).rejects.toEqual(new CLIError('Invalid map variant: vT_7!'));
+      ).rejects.toEqual(new CLIError('❌ Invalid map variant: vT_7!'));
     });
 
     it('throws error on invalid provider name', async () => {
@@ -560,7 +560,7 @@ describe('Interactive create CLI command', () => {
         .mockResolvedValueOnce({ init: true });
 
       await expect(Create.run(['-i'])).rejects.toEqual(
-        new CLIError('Invalid provider name: vT_7!')
+        new CLIError('❌ Invalid provider name: vT_7!')
       );
     });
 
@@ -582,7 +582,7 @@ describe('Interactive create CLI command', () => {
         //Init
         .mockResolvedValueOnce({ init: true });
       await expect(Create.run(['-u', 'SendSMS', '-i'])).rejects.toEqual(
-        new CLIError('"vT_7!" is not a valid lowercase identifier')
+        new CLIError('❌ "vT_7!" is not a valid lowercase identifier')
       );
     });
 
@@ -606,7 +606,7 @@ describe('Interactive create CLI command', () => {
 
       await expect(
         Create.run(['-v', '', '-u', 'SendSMS', '-i'])
-      ).rejects.toEqual(new CLIError(' is not a valid version'));
+      ).rejects.toEqual(new CLIError('❌  is not a valid version'));
     });
 
     it('throws error on invalid usecase', async () => {
@@ -628,7 +628,7 @@ describe('Interactive create CLI command', () => {
         .mockResolvedValueOnce({ init: true });
 
       await expect(Create.run(['-u', '7_L§', '-i'])).rejects.toEqual(
-        new CLIError('Invalid usecase name: 7_L§')
+        new CLIError('❌ Invalid usecase name: 7_L§')
       );
     });
   });

--- a/src/commands/lint.test.ts
+++ b/src/commands/lint.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { err, ok, SuperJson } from '@superfaceai/one-sdk';
 import { SDKExecutionError } from '@superfaceai/one-sdk/dist/internal/errors';
 import { mocked } from 'ts-jest/utils';
@@ -33,8 +32,8 @@ describe('lint CLI command', () => {
   describe('lint CLI command', () => {
     it('throws when super.json not found', async () => {
       mocked(detectSuperJson).mockResolvedValue(undefined);
-      await expect(Lint.run([])).rejects.toEqual(
-        new CLIError('❌ Unable to lint, super.json not found')
+      await expect(Lint.run([])).rejects.toThrow(
+        'Unable to lint, super.json not found'
       );
     });
 
@@ -43,16 +42,16 @@ describe('lint CLI command', () => {
       jest
         .spyOn(SuperJson, 'load')
         .mockResolvedValue(err(new SDKExecutionError('test error', [], [])));
-      await expect(Lint.run([])).rejects.toEqual(
-        new CLIError('❌ Unable to load super.json: test error')
+      await expect(Lint.run([])).rejects.toThrow(
+        'Unable to load super.json: test error'
       );
     });
 
     it('throws error on invalid scan flag', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
 
-      await expect(Lint.run(['-s test'])).rejects.toEqual(
-        new CLIError('Expected an integer but received:  test')
+      await expect(Lint.run(['-s test'])).rejects.toThrow(
+        'Expected an integer but received:  test'
       );
       expect(detectSuperJson).not.toHaveBeenCalled();
     }, 10000);
@@ -60,10 +59,8 @@ describe('lint CLI command', () => {
     it('throws error on scan flag higher than 5', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
 
-      await expect(Lint.run(['-s', '6'])).rejects.toEqual(
-        new CLIError(
-          '❌ --scan/-s : Number of levels to scan cannot be higher than 5'
-        )
+      await expect(Lint.run(['-s', '6'])).rejects.toThrow(
+        '--scan/-s : Number of levels to scan cannot be higher than 5'
       );
       expect(detectSuperJson).not.toHaveBeenCalled();
     }, 10000);
@@ -76,10 +73,8 @@ describe('lint CLI command', () => {
 
       await expect(
         Lint.run(['--profileId', 'U!0_', '--providerName', provider, '-s', '3'])
-      ).rejects.toEqual(
-        new CLIError(
-          '❌ Invalid profile id: "U!0_" is not a valid lowercase identifier'
-        )
+      ).rejects.toThrow(
+        'Invalid profile id: "U!0_" is not a valid lowercase identifier'
       );
       expect(detectSuperJson).not.toHaveBeenCalled();
       expect(loadSpy).not.toHaveBeenCalled();
@@ -100,7 +95,7 @@ describe('lint CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(new CLIError('❌ Invalid provider name: "U!0_"'));
+      ).rejects.toThrow('Invalid provider name: "U!0_"');
       expect(detectSuperJson).not.toHaveBeenCalled();
       expect(loadSpy).not.toHaveBeenCalled();
     }, 10000);
@@ -120,10 +115,8 @@ describe('lint CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Unable to lint, profile: "${profileId}" not found in super.json`
-        )
+      ).rejects.toThrow(
+        `Unable to lint, profile: "${profileId}" not found in super.json`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -154,10 +147,8 @@ describe('lint CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Unable to lint, provider: "${provider}" not found in profile: "${profileId}" in super.json`
-        )
+      ).rejects.toThrow(
+        `Unable to lint, provider: "${provider}" not found in profile: "${profileId}" in super.json`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -734,7 +725,7 @@ describe('lint CLI command', () => {
             '-s',
             '4',
           ])
-        ).rejects.toEqual(new CLIError('❌ Errors were found'));
+        ).rejects.toThrow('Errors were found');
 
         expect(lint).toHaveBeenCalledTimes(1);
         expect(lint).toHaveBeenCalledWith(

--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -100,17 +100,17 @@ export default class Lint extends Command {
     if (flags.profileId) {
       const parsedProfileId = parseDocumentId(flags.profileId);
       if (parsedProfileId.kind == 'error') {
-        throw userError(`❌ Invalid profile id: ${parsedProfileId.message}`, 1);
+        throw userError(`Invalid profile id: ${parsedProfileId.message}`, 1);
       }
     }
 
     if (flags.providerName) {
       if (!isValidProviderName(flags.providerName)) {
-        throw userError(`❌ Invalid provider name: "${flags.providerName}"`, 1);
+        throw userError(`Invalid provider name: "${flags.providerName}"`, 1);
       }
       if (!flags.profileId) {
         throw userError(
-          `❌ --profileId must be specified when using --providerName`,
+          `--profileId must be specified when using --providerName`,
           1
         );
       }
@@ -118,30 +118,27 @@ export default class Lint extends Command {
 
     if (flags.scan && (typeof flags.scan !== 'number' || flags.scan > 5)) {
       throw userError(
-        '❌ --scan/-s : Number of levels to scan cannot be higher than 5',
+        '--scan/-s : Number of levels to scan cannot be higher than 5',
         1
       );
     }
     const superPath = await detectSuperJson(process.cwd(), flags.scan);
     if (!superPath) {
-      throw userError('❌ Unable to lint, super.json not found', 1);
+      throw userError('Unable to lint, super.json not found', 1);
     }
     //Load super json
     const loadedResult = await SuperJson.load(joinPath(superPath, META_FILE));
     const superJson = loadedResult.match(
       v => v,
       err => {
-        throw userError(
-          `❌ Unable to load super.json: ${err.formatShort()}`,
-          1
-        );
+        throw userError(`Unable to load super.json: ${err.formatShort()}`, 1);
       }
     );
     //Check super.json
     if (flags.profileId) {
       if (!superJson.normalized.profiles[flags.profileId]) {
         throw userError(
-          `❌ Unable to lint, profile: "${flags.profileId}" not found in super.json`,
+          `Unable to lint, profile: "${flags.profileId}" not found in super.json`,
           1
         );
       }
@@ -152,7 +149,7 @@ export default class Lint extends Command {
           ]
         ) {
           throw userError(
-            `❌ Unable to lint, provider: "${flags.providerName}" not found in profile: "${flags.profileId}" in super.json`,
+            `Unable to lint, provider: "${flags.providerName}" not found in profile: "${flags.profileId}" in super.json`,
             1
           );
         }
@@ -210,7 +207,7 @@ export default class Lint extends Command {
     await outputStream.cleanup();
 
     if (totals[0] > 0) {
-      throw userError('❌ Errors were found', 1);
+      throw userError('Errors were found', 1);
     } else if (totals[1] > 0) {
       this.logCallback?.('⚠️ Warnings were found');
     }

--- a/src/commands/logout.test.ts
+++ b/src/commands/logout.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { ServiceClient, ServiceClientError } from '@superfaceai/service-client';
 
 import { MockStd, mockStd } from '../test/mock-std';
@@ -56,9 +55,7 @@ describe('Logout CLI command', () => {
         .spyOn(ServiceClient.prototype, 'signOut')
         .mockRejectedValue(mockErr);
 
-      await expect(Logout.run([])).rejects.toEqual(
-        new CLIError('❌ Error: test')
-      );
+      await expect(Logout.run([])).rejects.toThrow(' Error: test');
       expect(getInfoSpy).toHaveBeenCalled();
       expect(stderr.output).toEqual('');
       expect(stdout.output).toEqual('');

--- a/src/commands/logout.test.ts
+++ b/src/commands/logout.test.ts
@@ -56,7 +56,9 @@ describe('Logout CLI command', () => {
         .spyOn(ServiceClient.prototype, 'signOut')
         .mockRejectedValue(mockErr);
 
-      await expect(Logout.run([])).rejects.toEqual(new CLIError('test'));
+      await expect(Logout.run([])).rejects.toEqual(
+        new CLIError('❌ Error: test')
+      );
       expect(getInfoSpy).toHaveBeenCalled();
       expect(stderr.output).toEqual('');
       expect(stdout.output).toEqual('');

--- a/src/commands/publish.test.ts
+++ b/src/commands/publish.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { EXTENSIONS } from '@superfaceai/ast';
 import { err, ok, SuperJson } from '@superfaceai/one-sdk';
 import { SDKExecutionError } from '@superfaceai/one-sdk/dist/internal/errors';
@@ -83,7 +82,7 @@ describe('Publish CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(new CLIError('EEXIT: 0'));
+      ).rejects.toThrow('EEXIT: 0');
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
       expect(promptSpy).toHaveBeenCalledTimes(1);
@@ -108,10 +107,8 @@ describe('Publish CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          '❌ Invalid profile id: "U!0_" is not a valid lowercase identifier'
-        )
+      ).rejects.toThrow(
+        'Invalid profile id: "U!0_" is not a valid lowercase identifier'
       );
       expect(detectSuperJson).not.toHaveBeenCalled();
       expect(loadSpy).not.toHaveBeenCalled();
@@ -137,7 +134,7 @@ describe('Publish CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(new CLIError('❌ Invalid provider name: "U!0_"'));
+      ).rejects.toThrow('Invalid provider name: "U!0_"');
       expect(detectSuperJson).not.toHaveBeenCalled();
       expect(loadSpy).not.toHaveBeenCalled();
       expect(promptSpy).not.toHaveBeenCalled();
@@ -156,9 +153,7 @@ describe('Publish CLI command', () => {
           '--providerName',
           provider,
         ])
-      ).rejects.toEqual(
-        new CLIError('❌ Unable to publish, super.json not found')
-      );
+      ).rejects.toThrow('Unable to publish, super.json not found');
       expect(promptSpy).not.toHaveBeenCalled();
     });
 
@@ -178,7 +173,7 @@ describe('Publish CLI command', () => {
           '--providerName',
           provider,
         ])
-      ).rejects.toEqual(new CLIError('❌ Unable to load super.json: test'));
+      ).rejects.toThrow('Unable to load super.json: test');
       expect(promptSpy).not.toHaveBeenCalled();
     });
 
@@ -197,9 +192,7 @@ describe('Publish CLI command', () => {
           provider,
           '-s test',
         ])
-      ).rejects.toEqual(
-        new CLIError('Expected an integer but received:  test')
-      );
+      ).rejects.toThrow('Expected an integer but received:  test');
       expect(promptSpy).not.toHaveBeenCalled();
       expect(detectSuperJson).not.toHaveBeenCalled();
     }, 10000);
@@ -220,10 +213,8 @@ describe('Publish CLI command', () => {
           '-s',
           '6',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          '❌ --scan/-s : Number of levels to scan cannot be higher than 5'
-        )
+      ).rejects.toThrow(
+        '--scan/-s : Number of levels to scan cannot be higher than 5'
       );
       expect(promptSpy).not.toHaveBeenCalled();
       expect(detectSuperJson).not.toHaveBeenCalled();
@@ -248,10 +239,8 @@ describe('Publish CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Unable to publish, profile: "${profileId}" not found in super.json`
-        )
+      ).rejects.toThrow(
+        `Unable to publish, profile: "${profileId}" not found in super.json`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -289,10 +278,8 @@ describe('Publish CLI command', () => {
           '--providerName',
           provider,
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Profile path: "${mockPath}" must leads to "${EXTENSIONS.profile.source}" file`
-        )
+      ).rejects.toThrow(
+        `Profile path: "${mockPath}" must leads to "${EXTENSIONS.profile.source}" file`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -325,10 +312,8 @@ describe('Publish CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Unable to publish, provider: "${provider}" not found in profile: "${profileId}" in super.json`
-        )
+      ).rejects.toThrow(
+        `Unable to publish, provider: "${provider}" not found in profile: "${profileId}" in super.json`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -370,10 +355,8 @@ describe('Publish CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Map path: "${mockPath}" must leads to "${EXTENSIONS.map.source}" file`
-        )
+      ).rejects.toThrow(
+        `Map path: "${mockPath}" must leads to "${EXTENSIONS.map.source}" file`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -409,10 +392,8 @@ describe('Publish CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Unable to publish, provider: "${provider}" not found in super.json`
-        )
+      ).rejects.toThrow(
+        `Unable to publish, provider: "${provider}" not found in super.json`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -455,10 +436,8 @@ describe('Publish CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Provider path: "${mockPath}" must leads to ".json" file`
-        )
+      ).rejects.toThrow(
+        `Provider path: "${mockPath}" must leads to ".json" file`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -497,10 +476,8 @@ describe('Publish CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ When publishing profile, profile must be locally linked in super.json`
-        )
+      ).rejects.toThrow(
+        `When publishing profile, profile must be locally linked in super.json`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -539,10 +516,8 @@ describe('Publish CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ When publishing map, map must be locally linked in super.json`
-        )
+      ).rejects.toThrow(
+        `When publishing map, map must be locally linked in super.json`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -583,10 +558,8 @@ describe('Publish CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ When publishing provider, provider must have prefix "${UNVERIFIED_PROVIDER_PREFIX}"`
-        )
+      ).rejects.toThrow(
+        `When publishing provider, provider must have prefix "${UNVERIFIED_PROVIDER_PREFIX}"`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();
@@ -625,10 +598,8 @@ describe('Publish CLI command', () => {
           '-s',
           '3',
         ])
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ When publishing provider, provider must be locally linked in super.json`
-        )
+      ).rejects.toThrow(
+        `When publishing provider, provider must be locally linked in super.json`
       );
       expect(detectSuperJson).toHaveBeenCalled();
       expect(loadSpy).toHaveBeenCalled();

--- a/src/commands/publish.ts
+++ b/src/commands/publish.ts
@@ -94,16 +94,16 @@ export default class Publish extends Command {
     // Check inputs
     const parsedProfileId = parseDocumentId(flags.profileId);
     if (parsedProfileId.kind == 'error') {
-      throw userError(`❌ Invalid profile id: ${parsedProfileId.message}`, 1);
+      throw userError(`Invalid profile id: ${parsedProfileId.message}`, 1);
     }
 
     if (!isValidProviderName(flags.providerName)) {
-      throw userError(`❌ Invalid provider name: "${flags.providerName}"`, 1);
+      throw userError(`Invalid provider name: "${flags.providerName}"`, 1);
     }
 
     if (flags.scan && (typeof flags.scan !== 'number' || flags.scan > 5)) {
       throw userError(
-        '❌ --scan/-s : Number of levels to scan cannot be higher than 5',
+        '--scan/-s : Number of levels to scan cannot be higher than 5',
         1
       );
     }
@@ -111,16 +111,13 @@ export default class Publish extends Command {
     //Load super json
     const superPath = await detectSuperJson(process.cwd(), flags.scan);
     if (!superPath) {
-      throw userError('❌ Unable to publish, super.json not found', 1);
+      throw userError('Unable to publish, super.json not found', 1);
     }
     const loadedResult = await SuperJson.load(joinPath(superPath, META_FILE));
     const superJson = loadedResult.match(
       v => v,
       err => {
-        throw userError(
-          `❌ Unable to load super.json: ${err.formatShort()}`,
-          1
-        );
+        throw userError(`Unable to load super.json: ${err.formatShort()}`, 1);
       }
     );
 
@@ -128,7 +125,7 @@ export default class Publish extends Command {
     const profileSettings = superJson.normalized.profiles[flags.profileId];
     if (!profileSettings) {
       throw userError(
-        `❌ Unable to publish, profile: "${flags.profileId}" not found in super.json`,
+        `Unable to publish, profile: "${flags.profileId}" not found in super.json`,
         1
       );
     }
@@ -136,7 +133,7 @@ export default class Publish extends Command {
       profileSettings.providers[flags.providerName];
     if (!profileProviderSettings) {
       throw userError(
-        `❌ Unable to publish, provider: "${flags.providerName}" not found in profile: "${flags.profileId}" in super.json`,
+        `Unable to publish, provider: "${flags.providerName}" not found in profile: "${flags.profileId}" in super.json`,
         1
       );
     }
@@ -144,7 +141,7 @@ export default class Publish extends Command {
     const providerSettings = superJson.normalized.providers[flags.providerName];
     if (!providerSettings) {
       throw userError(
-        `❌ Unable to publish, provider: "${flags.providerName}" not found in super.json`,
+        `Unable to publish, provider: "${flags.providerName}" not found in super.json`,
         1
       );
     }
@@ -153,13 +150,13 @@ export default class Publish extends Command {
     if (documentType === 'profile') {
       if (!('file' in profileSettings)) {
         throw userError(
-          `❌ When publishing profile, profile must be locally linked in super.json`,
+          `When publishing profile, profile must be locally linked in super.json`,
           1
         );
       }
       if (!profileSettings.file.endsWith(EXTENSIONS.profile.source)) {
         throw userError(
-          `❌ Profile path: "${profileSettings.file}" must leads to "${EXTENSIONS.profile.source}" file`,
+          `Profile path: "${profileSettings.file}" must leads to "${EXTENSIONS.profile.source}" file`,
           1
         );
       }
@@ -168,13 +165,13 @@ export default class Publish extends Command {
     } else if (documentType === 'map') {
       if (!('file' in profileProviderSettings)) {
         throw userError(
-          `❌ When publishing map, map must be locally linked in super.json`,
+          `When publishing map, map must be locally linked in super.json`,
           1
         );
       }
       if (!profileProviderSettings.file.endsWith(EXTENSIONS.map.source)) {
         throw userError(
-          `❌ Map path: "${profileProviderSettings.file}" must leads to "${EXTENSIONS.map.source}" file`,
+          `Map path: "${profileProviderSettings.file}" must leads to "${EXTENSIONS.map.source}" file`,
           1
         );
       }
@@ -182,25 +179,25 @@ export default class Publish extends Command {
     } else if (documentType === 'provider') {
       if (!flags.providerName.startsWith(UNVERIFIED_PROVIDER_PREFIX)) {
         throw userError(
-          `❌ When publishing provider, provider must have prefix "${UNVERIFIED_PROVIDER_PREFIX}"`,
+          `When publishing provider, provider must have prefix "${UNVERIFIED_PROVIDER_PREFIX}"`,
           1
         );
       }
       if (!('file' in providerSettings) || !providerSettings.file) {
         throw userError(
-          `❌ When publishing provider, provider must be locally linked in super.json`,
+          `When publishing provider, provider must be locally linked in super.json`,
           1
         );
       }
       if (!providerSettings.file.endsWith('.json')) {
         throw userError(
-          `❌ Provider path: "${providerSettings.file}" must leads to ".json" file`,
+          `Provider path: "${providerSettings.file}" must leads to ".json" file`,
           1
         );
       }
     } else {
       throw userError(
-        '❌ Document type must be one of "map", "profile", "provider"',
+        'Document type must be one of "map", "profile", "provider"',
         1
       );
     }

--- a/src/commands/whoami.test.ts
+++ b/src/commands/whoami.test.ts
@@ -86,7 +86,9 @@ describe('Whoami CLI command', () => {
         .spyOn(ServiceClient.prototype, 'getUserInfo')
         .mockRejectedValue(mockErr);
 
-      await expect(Whoami.run([])).rejects.toEqual(new CLIError('test'));
+      await expect(Whoami.run([])).rejects.toEqual(
+        new CLIError('❌ Error: test')
+      );
       expect(getInfoSpy).toHaveBeenCalled();
       expect(stderr.output).toEqual('');
       expect(stdout.output).toEqual('');

--- a/src/commands/whoami.test.ts
+++ b/src/commands/whoami.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { ServiceApiError, ServiceClient } from '@superfaceai/service-client';
 
 import { MockStd, mockStd } from '../test/mock-std';
@@ -86,9 +85,7 @@ describe('Whoami CLI command', () => {
         .spyOn(ServiceClient.prototype, 'getUserInfo')
         .mockRejectedValue(mockErr);
 
-      await expect(Whoami.run([])).rejects.toEqual(
-        new CLIError('❌ Error: test')
-      );
+      await expect(Whoami.run([])).rejects.toThrow('Error: test');
       expect(getInfoSpy).toHaveBeenCalled();
       expect(stderr.output).toEqual('');
       expect(stdout.output).toEqual('');

--- a/src/common/document.test.ts
+++ b/src/common/document.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { DocumentType } from '@superfaceai/ast';
 import { parseProfileId } from '@superfaceai/parser';
 import { mocked } from 'ts-jest/utils';
@@ -66,7 +65,7 @@ describe('Document functions', () => {
       expect(trimExtension('test.suma.ast.json')).toEqual('test');
       expect(trimExtension('test.supr.ast.json')).toEqual('test');
       expect(() => trimExtension('test.json')).toThrow(
-        new CLIError('❌ Could not infer document type')
+        'Could not infer document type'
       );
     });
   });
@@ -106,7 +105,7 @@ describe('Document functions', () => {
         message: 'test err',
       });
       expect(() => constructProfileSettings(['first'])).toThrow(
-        new CLIError('❌ Wrong profile Id')
+        'Wrong profile Id'
       );
     });
   });

--- a/src/common/document.test.ts
+++ b/src/common/document.test.ts
@@ -66,7 +66,7 @@ describe('Document functions', () => {
       expect(trimExtension('test.suma.ast.json')).toEqual('test');
       expect(trimExtension('test.supr.ast.json')).toEqual('test');
       expect(() => trimExtension('test.json')).toThrow(
-        new CLIError('Could not infer document type')
+        new CLIError('❌ Could not infer document type')
       );
     });
   });
@@ -106,7 +106,7 @@ describe('Document functions', () => {
         message: 'test err',
       });
       expect(() => constructProfileSettings(['first'])).toThrow(
-        new CLIError('Wrong profile Id')
+        new CLIError('❌ Wrong profile Id')
       );
     });
   });

--- a/src/common/error.test.ts
+++ b/src/common/error.test.ts
@@ -13,14 +13,14 @@ describe('Error functions', () => {
     it('throws user error correctly', async () => {
       expect(() => {
         throw userError('user error', 1);
-      }).toThrow(new CLIError('user error'));
+      }).toThrow(new CLIError('❌ user error'));
     });
 
     it('throws developer error on negative exit code', async () => {
       expect(() => {
         throw userError('some error', -1);
       }).toThrow(
-        new CLIError('Internal error: expected positive error code', {
+        new CLIError('❌ Internal error: expected positive error code', {
           exit: -1,
         })
       );
@@ -31,14 +31,14 @@ describe('Error functions', () => {
     it('throws developer error correctly', async () => {
       expect(() => {
         throw developerError('developer error', 1);
-      }).toThrow(new CLIError('Internal error: developer error'));
+      }).toThrow(new CLIError('❌ Internal error: developer error'));
     });
 
     it('throws developer error on negative exit code', async () => {
       expect(() => {
         throw developerError('some error', -1);
       }).toThrow(
-        new CLIError('Internal error: expected positive error code', {
+        new CLIError('❌ Internal error: expected positive error code', {
           exit: -1,
         })
       );
@@ -48,19 +48,19 @@ describe('Error functions', () => {
   describe('when asserting error is generic', () => {
     it('throws developer error correctly', async () => {
       expect(() => assertIsGenericError(null)).toThrow(
-        new CLIError('Internal error: unexpected error: null')
+        new CLIError('❌ Internal error: unexpected error: null')
       );
       expect(() => assertIsGenericError(undefined)).toThrow(
-        new CLIError('Internal error: unexpected error: undefined')
+        new CLIError('❌ Internal error: unexpected error: undefined')
       );
       expect(() => assertIsGenericError({})).toThrow(
-        new CLIError('Internal error: unexpected error: {}')
+        new CLIError('❌ Internal error: unexpected error: {}')
       );
       expect(() => assertIsGenericError({ code: 'test' })).toThrow(
-        new CLIError("Internal error: unexpected error: { code: 'test' }")
+        new CLIError("❌ Internal error: unexpected error: { code: 'test' }")
       );
       expect(() => assertIsGenericError({ message: 2 })).toThrow(
-        new CLIError('Internal error: unexpected error: { message: 2 }')
+        new CLIError('❌ Internal error: unexpected error: { message: 2 }')
       );
     });
 
@@ -72,19 +72,19 @@ describe('Error functions', () => {
   describe('when asserting error is IO error', () => {
     it('throws developer error correctly', async () => {
       expect(() => assertIsIOError(null)).toThrow(
-        new CLIError('Internal error: unexpected error: null')
+        new CLIError('❌ Internal error: unexpected error: null')
       );
       expect(() => assertIsIOError(undefined)).toThrow(
-        new CLIError('Internal error: unexpected error: undefined')
+        new CLIError('❌ Internal error: unexpected error: undefined')
       );
       expect(() => assertIsIOError({})).toThrow(
-        new CLIError('Internal error: unexpected error: {}')
+        new CLIError('❌ Internal error: unexpected error: {}')
       );
       expect(() => assertIsIOError({ code: 2 })).toThrow(
-        new CLIError('Internal error: unexpected error: { code: 2 }')
+        new CLIError('❌ Internal error: unexpected error: { code: 2 }')
       );
       expect(() => assertIsIOError({ message: 2 })).toThrow(
-        new CLIError('Internal error: unexpected error: { message: 2 }')
+        new CLIError('❌ Internal error: unexpected error: { message: 2 }')
       );
     });
 
@@ -96,25 +96,25 @@ describe('Error functions', () => {
   describe('when asserting error is exec error', () => {
     it('throws developer error correctly', async () => {
       expect(() => assertIsExecError(null)).toThrow(
-        new CLIError('Internal error: unexpected error: null')
+        new CLIError('❌ Internal error: unexpected error: null')
       );
       expect(() => assertIsExecError(undefined)).toThrow(
-        new CLIError('Internal error: unexpected error: undefined')
+        new CLIError('❌ Internal error: unexpected error: undefined')
       );
       expect(() => assertIsIOError({})).toThrow(
-        new CLIError('Internal error: unexpected error: {}')
+        new CLIError('❌ Internal error: unexpected error: {}')
       );
       expect(() => assertIsExecError({ code: 2 })).toThrow(
-        new CLIError('Internal error: unexpected error: { code: 2 }')
+        new CLIError('❌ Internal error: unexpected error: { code: 2 }')
       );
       expect(() => assertIsExecError({ message: 2 })).toThrow(
-        new CLIError('Internal error: unexpected error: { message: 2 }')
+        new CLIError('❌ Internal error: unexpected error: { message: 2 }')
       );
       expect(() => assertIsExecError({ stdout: 2 })).toThrow(
-        new CLIError('Internal error: unexpected error: { stdout: 2 }')
+        new CLIError('❌ Internal error: unexpected error: { stdout: 2 }')
       );
       expect(() => assertIsExecError({ stderr: 2 })).toThrow(
-        new CLIError('Internal error: unexpected error: { stderr: 2 }')
+        new CLIError('❌ Internal error: unexpected error: { stderr: 2 }')
       );
     });
 

--- a/src/common/error.ts
+++ b/src/common/error.ts
@@ -13,7 +13,7 @@ export function userError(message: string, code: number): CLIError {
     throw developerError('expected positive error code', 1);
   }
 
-  return new CLIError(message, { exit: code });
+  return new CLIError(`❌ ${message}`, { exit: code });
 }
 
 /**
@@ -28,7 +28,7 @@ export function developerError(message: string, code: number): CLIError {
     throw developerError('expected positive error code', 1);
   }
 
-  return new CLIError(`Internal error: ${message}`, { exit: -code });
+  return new CLIError(`❌ Internal error: ${message}`, { exit: -code });
 }
 
 export function assertIsGenericError(

--- a/src/common/flags.test.ts
+++ b/src/common/flags.test.ts
@@ -1,5 +1,3 @@
-import { CLIError } from '@oclif/errors';
-
 import { documentTypeFlag, skipFileFlag } from './flags';
 
 describe('Custom flags', () => {
@@ -23,11 +21,7 @@ describe('Custom flags', () => {
     it('throws developer error on invalid input', async () => {
       expect(() => {
         documentTypeFlag.parse('invalid', undefined);
-      }).toThrow(
-        new CLIError('❌ Internal error: unexpected enum variant', {
-          exit: -1,
-        })
-      );
+      }).toThrow('Internal error: unexpected enum variant');
     });
   });
 
@@ -47,11 +41,7 @@ describe('Custom flags', () => {
     it('throws developer error on invalid input', async () => {
       expect(() => {
         skipFileFlag().parse('invalid', undefined);
-      }).toThrow(
-        new CLIError('❌ Internal error: unexpected enum variant', {
-          exit: -1,
-        })
-      );
+      }).toThrow('Internal error: unexpected enum variant');
     });
   });
 });

--- a/src/common/flags.test.ts
+++ b/src/common/flags.test.ts
@@ -24,7 +24,7 @@ describe('Custom flags', () => {
       expect(() => {
         documentTypeFlag.parse('invalid', undefined);
       }).toThrow(
-        new CLIError('Internal error: unexpected enum variant', {
+        new CLIError('❌ Internal error: unexpected enum variant', {
           exit: -1,
         })
       );
@@ -48,7 +48,7 @@ describe('Custom flags', () => {
       expect(() => {
         skipFileFlag().parse('invalid', undefined);
       }).toThrow(
-        new CLIError('Internal error: unexpected enum variant', {
+        new CLIError('❌ Internal error: unexpected enum variant', {
           exit: -1,
         })
       );

--- a/src/common/http.test.ts
+++ b/src/common/http.test.ts
@@ -133,7 +133,7 @@ describe('HTTP functions', () => {
         );
 
       await expect(fetchProviders(profileId)).rejects.toEqual(
-        new CLIError(new ServiceApiError(mockErrResponse).message)
+        new CLIError(`❌ ${new ServiceApiError(mockErrResponse).message}`)
       );
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -218,7 +218,7 @@ describe('HTTP functions', () => {
         );
 
       await expect(fetchProfileInfo(profileId)).rejects.toEqual(
-        new CLIError(new ServiceApiError(mockErrResponse).message)
+        new CLIError(`❌ ${new ServiceApiError(mockErrResponse).message}`)
       );
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -287,7 +287,7 @@ describe('HTTP functions', () => {
         );
 
       await expect(fetchProfile(profileId)).rejects.toEqual(
-        new CLIError(new ServiceApiError(mockErrResponse).message)
+        new CLIError(`❌ ${new ServiceApiError(mockErrResponse).message}`)
       );
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -384,7 +384,7 @@ describe('HTTP functions', () => {
         );
 
       await expect(fetchProfileAST(profileId)).rejects.toEqual(
-        new CLIError(new ServiceApiError(mockErrResponse).message)
+        new CLIError(`❌ ${new ServiceApiError(mockErrResponse).message}`)
       );
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -728,7 +728,7 @@ describe('HTTP functions', () => {
       await expect(
         fetchMapAST(profileName, provider, scope, version)
       ).rejects.toEqual(
-        new CLIError(new ServiceApiError(mockErrResponse).message)
+        new CLIError(`❌ ${new ServiceApiError(mockErrResponse).message}`)
       );
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);

--- a/src/common/http.test.ts
+++ b/src/common/http.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import {
   ApiKeyPlacement,
   AstMetadata,
@@ -132,8 +131,8 @@ describe('HTTP functions', () => {
           mockResponse(404, 'Not Found', undefined, mockErrResponse)
         );
 
-      await expect(fetchProviders(profileId)).rejects.toEqual(
-        new CLIError(`❌ ${new ServiceApiError(mockErrResponse).message}`)
+      await expect(fetchProviders(profileId)).rejects.toThrow(
+        new ServiceApiError(mockErrResponse).message
       );
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -217,8 +216,8 @@ describe('HTTP functions', () => {
           mockResponse(404, 'Not Found', undefined, mockErrResponse)
         );
 
-      await expect(fetchProfileInfo(profileId)).rejects.toEqual(
-        new CLIError(`❌ ${new ServiceApiError(mockErrResponse).message}`)
+      await expect(fetchProfileInfo(profileId)).rejects.toThrow(
+        new ServiceApiError(mockErrResponse).message
       );
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -286,8 +285,8 @@ describe('HTTP functions', () => {
           mockResponse(404, 'Not Found', undefined, mockErrResponse)
         );
 
-      await expect(fetchProfile(profileId)).rejects.toEqual(
-        new CLIError(`❌ ${new ServiceApiError(mockErrResponse).message}`)
+      await expect(fetchProfile(profileId)).rejects.toThrow(
+        new ServiceApiError(mockErrResponse).message
       );
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -383,8 +382,8 @@ describe('HTTP functions', () => {
           mockResponse(404, 'Not Found', undefined, mockErrResponse)
         );
 
-      await expect(fetchProfileAST(profileId)).rejects.toEqual(
-        new CLIError(`❌ ${new ServiceApiError(mockErrResponse).message}`)
+      await expect(fetchProfileAST(profileId)).rejects.toThrow(
+        new ServiceApiError(mockErrResponse).message
       );
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
@@ -727,9 +726,7 @@ describe('HTTP functions', () => {
 
       await expect(
         fetchMapAST(profileName, provider, scope, version)
-      ).rejects.toEqual(
-        new CLIError(`❌ ${new ServiceApiError(mockErrResponse).message}`)
-      );
+      ).rejects.toThrow(new ServiceApiError(mockErrResponse).message);
 
       expect(fetchSpy).toHaveBeenCalledTimes(1);
       expect(fetchSpy).toHaveBeenCalledWith(

--- a/src/logic/compile.test.ts
+++ b/src/logic/compile.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { Parser } from '@superfaceai/one-sdk';
 import { mocked } from 'ts-jest/utils';
 
@@ -181,10 +180,8 @@ describe('Compile CLI logic', () => {
       const parseProfileSpy = jest.spyOn(Parser, 'parseProfile');
       const clearCacheSpy = jest.spyOn(Parser, 'clearCache');
 
-      await expect(compile(profiles)).rejects.toEqual(
-        new CLIError(
-          '❌ Path: "first/profile.supr" for profile first/profile does not exist'
-        )
+      await expect(compile(profiles)).rejects.toThrow(
+        'Path: "first/profile.supr" for profile first/profile does not exist'
       );
       expect(parseProfileSpy).not.toHaveBeenCalled();
 
@@ -205,10 +202,8 @@ describe('Compile CLI logic', () => {
         return Promise.resolve(mockProfileContent);
       });
 
-      await expect(compile(profiles)).rejects.toEqual(
-        new CLIError(
-          '❌ Path: "first/profile/first/map.suma" for map first/profile.first does not exist'
-        )
+      await expect(compile(profiles)).rejects.toThrow(
+        'Path: "first/profile/first/map.suma" for map first/profile.first does not exist'
       );
       expect(parseProfileSpy).toHaveBeenNthCalledWith(
         1,

--- a/src/logic/compile.ts
+++ b/src/logic/compile.ts
@@ -28,7 +28,7 @@ export async function compile(
       options?.logCb?.(`Compiling profile ${profile.id.toString()}`);
       if (!(await exists(profile.path))) {
         throw userError(
-          `❌ Path: "${
+          `Path: "${
             profile.path
           }" for profile ${profile.id.toString()} does not exist`,
           1
@@ -51,7 +51,7 @@ export async function compile(
         );
         if (!(await exists(map.path))) {
           throw userError(
-            `❌ Path: "${map.path}" for map ${profile.id.toString()}.${
+            `Path: "${map.path}" for map ${profile.id.toString()}.${
               map.provider
             } does not exist`,
             1

--- a/src/logic/configure.test.ts
+++ b/src/logic/configure.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import {
   ApiKeyPlacement,
   HttpScheme,
@@ -370,8 +369,8 @@ describe('Configure CLI logic', () => {
     it('throws on error', async () => {
       mocked(fetchProviderInfo).mockRejectedValue(new Error('test'));
 
-      await expect(getProviderFromStore(providerName)).rejects.toEqual(
-        new CLIError('❌ Error: test')
+      await expect(getProviderFromStore(providerName)).rejects.toThrow(
+        'Error: test'
       );
     });
   });
@@ -780,7 +779,7 @@ describe('Configure CLI logic', () => {
             localProvider: 'some/error/path',
           },
         })
-      ).rejects.toEqual(new CLIError('❌ Error: test'));
+      ).rejects.toThrow('Error: test');
 
       expect(fetchProviderInfo).not.toHaveBeenCalled();
 
@@ -806,10 +805,8 @@ describe('Configure CLI logic', () => {
           provider: providerName,
           profileId: mockProfileId,
         })
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ profile ${mockProfileId.id} not found in "some/path/super.json".`
-        )
+      ).rejects.toThrow(
+        `profile ${mockProfileId.id} not found in "some/path/super.json".`
       );
 
       expect(fetchProviderInfo).not.toHaveBeenCalled();

--- a/src/logic/configure.test.ts
+++ b/src/logic/configure.test.ts
@@ -371,7 +371,7 @@ describe('Configure CLI logic', () => {
       mocked(fetchProviderInfo).mockRejectedValue(new Error('test'));
 
       await expect(getProviderFromStore(providerName)).rejects.toEqual(
-        new CLIError('test')
+        new CLIError('❌ Error: test')
       );
     });
   });
@@ -780,7 +780,7 @@ describe('Configure CLI logic', () => {
             localProvider: 'some/error/path',
           },
         })
-      ).rejects.toEqual(new CLIError('test'));
+      ).rejects.toEqual(new CLIError('❌ Error: test'));
 
       expect(fetchProviderInfo).not.toHaveBeenCalled();
 

--- a/src/logic/configure.ts
+++ b/src/logic/configure.ts
@@ -164,7 +164,7 @@ export async function installProvider(parameters: {
   //Check profile existance
   if (!superJson.normalized.profiles[parameters.profileId.id]) {
     throw userError(
-      `❌ profile ${parameters.profileId.id} not found in "${superJsonPath}".`,
+      `profile ${parameters.profileId.id} not found in "${superJsonPath}".`,
       1
     );
   }
@@ -226,9 +226,7 @@ export async function installProvider(parameters: {
   if (providerInfo.securitySchemes && providerInfo.securitySchemes.length > 0) {
     // inform user about instlaled security schemes
     if (numOfConfigured === 0) {
-      parameters.options?.logCb?.(
-        `❌ No security schemes have been configured.`
-      );
+      parameters.options?.logCb?.(`No security schemes have been configured.`);
     } else if (numOfConfigured < providerInfo.securitySchemes.length) {
       parameters.options?.logCb?.(
         `⚠️ Some security schemes have been configured. Configured ${numOfConfigured} out of ${providerInfo.securitySchemes.length}.`
@@ -258,7 +256,7 @@ export async function installProvider(parameters: {
         ];
       if (superJsonValue === undefined) {
         parameters.options?.logCb?.(
-          `❌ Parameter ${parameter.name}${description} has not been configured.\nPlease, configure this parameter manualy in super.json on path: ${superJson.path}`
+          `Parameter ${parameter.name}${description} has not been configured.\nPlease, configure this parameter manualy in super.json on path: ${superJson.path}`
         );
       } else {
         parameters.options?.logCb?.(

--- a/src/logic/create.test.ts
+++ b/src/logic/create.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { EXTENSIONS } from '@superfaceai/ast';
 import { err, ok, SuperJson } from '@superfaceai/one-sdk';
 import { SDKExecutionError } from '@superfaceai/one-sdk/dist/internal/errors';
@@ -1008,8 +1007,8 @@ describe('Create logic', () => {
             superPath: mockSuperPath,
           },
         })
-      ).rejects.toEqual(
-        new CLIError('❌ Provider name must be provided when generating a map.')
+      ).rejects.toThrow(
+        'Provider name must be provided when generating a map.'
       );
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -1057,10 +1056,8 @@ describe('Create logic', () => {
             superPath: mockSuperPath,
           },
         })
-      ).rejects.toEqual(
-        new CLIError(
-          '❌ Provider name must be provided when generating a provider.'
-        )
+      ).rejects.toThrow(
+        '❌ Provider name must be provided when generating a provider.'
       );
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -1107,9 +1104,7 @@ describe('Create logic', () => {
             superPath: mockSuperPath,
           },
         })
-      ).rejects.toEqual(
-        new CLIError('❌ Profile name must be provided when generating a map.')
-      );
+      ).rejects.toThrow('Profile name must be provided when generating a map.');
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
 
@@ -1155,10 +1150,8 @@ describe('Create logic', () => {
             superPath: mockSuperPath,
           },
         })
-      ).rejects.toEqual(
-        new CLIError(
-          '❌ Profile name must be provided when generating a profile.'
-        )
+      ).rejects.toThrow(
+        'Profile name must be provided when generating a profile.'
       );
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -1206,8 +1199,8 @@ describe('Create logic', () => {
             superPath: mockSuperPath,
           },
         })
-      ).rejects.toEqual(
-        new CLIError('❌ Provider name must be provided when generating a map.')
+      ).rejects.toThrow(
+        'Provider name must be provided when generating a map.'
       );
 
       expect(loadSpy).toHaveBeenCalledTimes(1);

--- a/src/logic/create.test.ts
+++ b/src/logic/create.test.ts
@@ -1009,7 +1009,7 @@ describe('Create logic', () => {
           },
         })
       ).rejects.toEqual(
-        new CLIError('Provider name must be provided when generating a map.')
+        new CLIError('❌ Provider name must be provided when generating a map.')
       );
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -1059,7 +1059,7 @@ describe('Create logic', () => {
         })
       ).rejects.toEqual(
         new CLIError(
-          'Provider name must be provided when generating a provider.'
+          '❌ Provider name must be provided when generating a provider.'
         )
       );
 
@@ -1108,7 +1108,7 @@ describe('Create logic', () => {
           },
         })
       ).rejects.toEqual(
-        new CLIError('Profile name must be provided when generating a map.')
+        new CLIError('❌ Profile name must be provided when generating a map.')
       );
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -1156,7 +1156,9 @@ describe('Create logic', () => {
           },
         })
       ).rejects.toEqual(
-        new CLIError('Profile name must be provided when generating a profile.')
+        new CLIError(
+          '❌ Profile name must be provided when generating a profile.'
+        )
       );
 
       expect(loadSpy).toHaveBeenCalledTimes(1);
@@ -1205,7 +1207,7 @@ describe('Create logic', () => {
           },
         })
       ).rejects.toEqual(
-        new CLIError('Provider name must be provided when generating a map.')
+        new CLIError('❌ Provider name must be provided when generating a map.')
       );
 
       expect(loadSpy).toHaveBeenCalledTimes(1);

--- a/src/logic/init.test.ts
+++ b/src/logic/init.test.ts
@@ -134,7 +134,7 @@ describe('Init logic', () => {
 
       await expect(
         generateSpecifiedProfiles(mockPath, mockSuperJson, mockProfileIds)
-      ).rejects.toEqual(new CLIError('Wrong profile Id'));
+      ).rejects.toEqual(new CLIError('❌ Wrong profile Id'));
 
       expect(parseProfileId).toHaveBeenCalledTimes(1);
       expect(parseProfileId).toHaveBeenCalledWith('first-profile-id');

--- a/src/logic/init.test.ts
+++ b/src/logic/init.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import { ok, SuperJson } from '@superfaceai/one-sdk';
 import { parseProfileId } from '@superfaceai/parser';
 import { mocked } from 'ts-jest/utils';
@@ -134,7 +133,7 @@ describe('Init logic', () => {
 
       await expect(
         generateSpecifiedProfiles(mockPath, mockSuperJson, mockProfileIds)
-      ).rejects.toEqual(new CLIError('❌ Wrong profile Id'));
+      ).rejects.toThrow('Wrong profile Id');
 
       expect(parseProfileId).toHaveBeenCalledTimes(1);
       expect(parseProfileId).toHaveBeenCalledWith('first-profile-id');

--- a/src/logic/lint.test.ts
+++ b/src/logic/lint.test.ts
@@ -308,7 +308,7 @@ describe('Lint logic', () => {
       const mockMapPath = 'testMapPath';
       expect(() =>
         isValidMapId(mockValidProfileHeader, mocValidMapHeader, mockMapPath)
-      ).toThrowError(new CLIError('parse-error'));
+      ).toThrowError(new CLIError('❌ parse-error'));
     });
   });
 

--- a/src/logic/lint.test.ts
+++ b/src/logic/lint.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import {
   AstMetadata,
   MapDocumentNode,
@@ -308,7 +307,7 @@ describe('Lint logic', () => {
       const mockMapPath = 'testMapPath';
       expect(() =>
         isValidMapId(mockValidProfileHeader, mocValidMapHeader, mockMapPath)
-      ).toThrowError(new CLIError('❌ parse-error'));
+      ).toThrow('parse-error');
     });
   });
 

--- a/src/logic/login.test.ts
+++ b/src/logic/login.test.ts
@@ -239,7 +239,7 @@ describe('Login logic', () => {
 
       await expect(login({ logCb: stdout, warnCb: stderr })).rejects.toEqual(
         new CLIError(
-          `Unable to get auth token, request ended with status: ${VerificationStatus.EXPIRED}`
+          `❌ Unable to get auth token, request ended with status: ${VerificationStatus.EXPIRED}`
         )
       );
 
@@ -280,7 +280,7 @@ describe('Login logic', () => {
 
       await expect(login({ logCb: stdout, warnCb: stderr })).rejects.toEqual(
         new CLIError(
-          `Request ended with status: ${VerificationStatus.CONFIRMED} but does not contain auth token`
+          `❌ Request ended with status: ${VerificationStatus.CONFIRMED} but does not contain auth token`
         )
       );
 
@@ -311,7 +311,7 @@ describe('Login logic', () => {
 
       await expect(login({ logCb: stdout, warnCb: stderr })).rejects.toEqual(
         new CLIError(
-          `Attempt to login ended with: ${mockInitResponse.title}: ${
+          `❌ Attempt to login ended with: ${mockInitResponse.title}: ${
             mockInitResponse.detail || ''
           }`
         )
@@ -333,7 +333,9 @@ describe('Login logic', () => {
         .mockResolvedValue(mockInitResponse);
 
       await expect(login({ logCb: stdout, warnCb: stderr })).rejects.toEqual(
-        new CLIError(`Attempt to login ended with: ${mockInitResponse.title}`)
+        new CLIError(
+          `❌ Attempt to login ended with: ${mockInitResponse.title}`
+        )
       );
 
       expect(initSpy).toHaveBeenCalledTimes(1);

--- a/src/logic/login.test.ts
+++ b/src/logic/login.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import {
   CLILoginResponse,
   ServiceClient,
@@ -237,10 +236,8 @@ describe('Login logic', () => {
 
       const loginSpy = jest.spyOn(ServiceClient.prototype, 'login');
 
-      await expect(login({ logCb: stdout, warnCb: stderr })).rejects.toEqual(
-        new CLIError(
-          `❌ Unable to get auth token, request ended with status: ${VerificationStatus.EXPIRED}`
-        )
+      await expect(login({ logCb: stdout, warnCb: stderr })).rejects.toThrow(
+        `Unable to get auth token, request ended with status: ${VerificationStatus.EXPIRED}`
       );
 
       expect(initSpy).toHaveBeenCalledTimes(1);
@@ -278,10 +275,8 @@ describe('Login logic', () => {
 
       const loginSpy = jest.spyOn(ServiceClient.prototype, 'login');
 
-      await expect(login({ logCb: stdout, warnCb: stderr })).rejects.toEqual(
-        new CLIError(
-          `❌ Request ended with status: ${VerificationStatus.CONFIRMED} but does not contain auth token`
-        )
+      await expect(login({ logCb: stdout, warnCb: stderr })).rejects.toThrow(
+        `Request ended with status: ${VerificationStatus.CONFIRMED} but does not contain auth token`
       );
 
       expect(initSpy).toHaveBeenCalledTimes(1);
@@ -309,12 +304,10 @@ describe('Login logic', () => {
         .spyOn(ServiceClient.prototype, 'cliLogin')
         .mockResolvedValue(mockInitResponse);
 
-      await expect(login({ logCb: stdout, warnCb: stderr })).rejects.toEqual(
-        new CLIError(
-          `❌ Attempt to login ended with: ${mockInitResponse.title}: ${
-            mockInitResponse.detail || ''
-          }`
-        )
+      await expect(login({ logCb: stdout, warnCb: stderr })).rejects.toThrow(
+        `Attempt to login ended with: ${mockInitResponse.title}: ${
+          mockInitResponse.detail || ''
+        }`
       );
 
       expect(initSpy).toHaveBeenCalledTimes(1);
@@ -332,10 +325,8 @@ describe('Login logic', () => {
         .spyOn(ServiceClient.prototype, 'cliLogin')
         .mockResolvedValue(mockInitResponse);
 
-      await expect(login({ logCb: stdout, warnCb: stderr })).rejects.toEqual(
-        new CLIError(
-          `❌ Attempt to login ended with: ${mockInitResponse.title}`
-        )
+      await expect(login({ logCb: stdout, warnCb: stderr })).rejects.toThrow(
+        `Attempt to login ended with: ${mockInitResponse.title}`
       );
 
       expect(initSpy).toHaveBeenCalledTimes(1);

--- a/src/logic/publish.test.ts
+++ b/src/logic/publish.test.ts
@@ -607,7 +607,7 @@ describe('Publish logic', () => {
         )
       ).rejects.toEqual(
         new CLIError(
-          `Profile: "${mockProfileId}" not found on local file system`
+          `❌ Profile: "${mockProfileId}" not found on local file system`
         )
       );
 
@@ -1023,7 +1023,7 @@ describe('Publish logic', () => {
         )
       ).rejects.toEqual(
         new CLIError(
-          `Provider: "${mockMapDocument.header.provider}" does not exist in Superface store and it does not start with: "${UNVERIFIED_PROVIDER_PREFIX}" prefix.\nPlease, rename provider: "${mockMapDocument.header.provider}" or use existing provider.`
+          `❌ Provider: "${mockMapDocument.header.provider}" does not exist in Superface store and it does not start with: "${UNVERIFIED_PROVIDER_PREFIX}" prefix.\nPlease, rename provider: "${mockMapDocument.header.provider}" or use existing provider.`
         )
       );
 
@@ -1103,7 +1103,7 @@ describe('Publish logic', () => {
         )
       ).rejects.toEqual(
         new CLIError(
-          `Map for profile: "${mockProfileId}" and provider: "${mockProviderName}" not found on local filesystem`
+          `❌ Map for profile: "${mockProfileId}" and provider: "${mockProviderName}" not found on local filesystem`
         )
       );
 
@@ -1551,7 +1551,7 @@ describe('Publish logic', () => {
         )
       ).rejects.toEqual(
         new CLIError(
-          `Provider: "${mockProviderName}" not found on local file system`
+          `❌ Provider: "${mockProviderName}" not found on local file system`
         )
       );
 

--- a/src/logic/publish.test.ts
+++ b/src/logic/publish.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import {
   AstMetadata,
   MapDocumentNode,
@@ -605,10 +604,8 @@ describe('Publish logic', () => {
           undefined,
           { dryRun: true }
         )
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Profile: "${mockProfileId}" not found on local file system`
-        )
+      ).rejects.toThrow(
+        `Profile: "${mockProfileId}" not found on local file system`
       );
 
       expect(loadProfile).toHaveBeenCalledWith(
@@ -1021,10 +1018,8 @@ describe('Publish logic', () => {
           {},
           DEFAULT_PROFILE_VERSION_STR
         )
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Provider: "${mockMapDocument.header.provider}" does not exist in Superface store and it does not start with: "${UNVERIFIED_PROVIDER_PREFIX}" prefix.\nPlease, rename provider: "${mockMapDocument.header.provider}" or use existing provider.`
-        )
+      ).rejects.toThrow(
+        `Provider: "${mockMapDocument.header.provider}" does not exist in Superface store and it does not start with: "${UNVERIFIED_PROVIDER_PREFIX}" prefix.\nPlease, rename provider: "${mockMapDocument.header.provider}" or use existing provider.`
       );
 
       expect(createSpy).not.toHaveBeenCalled();
@@ -1101,10 +1096,8 @@ describe('Publish logic', () => {
           DEFAULT_PROFILE_VERSION_STR,
           { dryRun: true }
         )
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Map for profile: "${mockProfileId}" and provider: "${mockProviderName}" not found on local filesystem`
-        )
+      ).rejects.toThrow(
+        `Map for profile: "${mockProfileId}" and provider: "${mockProviderName}" not found on local filesystem`
       );
 
       expect(loadProfile).toHaveBeenCalledWith(
@@ -1367,10 +1360,8 @@ describe('Publish logic', () => {
           DEFAULT_PROFILE_VERSION_STR,
           { dryRun: true }
         )
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ When publishing provider, provider name: "${mockProviderName}" in provider.json must have prefix "${UNVERIFIED_PROVIDER_PREFIX}"`
-        )
+      ).rejects.toThrow(
+        `When publishing provider, provider name: "${mockProviderName}" in provider.json must have prefix "${UNVERIFIED_PROVIDER_PREFIX}"`
       );
 
       expect(createSpy).not.toHaveBeenCalled();
@@ -1549,10 +1540,8 @@ describe('Publish logic', () => {
           DEFAULT_PROFILE_VERSION_STR,
           { dryRun: true }
         )
-      ).rejects.toEqual(
-        new CLIError(
-          `❌ Provider: "${mockProviderName}" not found on local file system`
-        )
+      ).rejects.toThrow(
+        `Provider: "${mockProviderName}" not found on local file system`
       );
 
       expect(loadProfile).toHaveBeenCalledWith(

--- a/src/logic/publish.ts
+++ b/src/logic/publish.ts
@@ -159,7 +159,7 @@ export async function publish(
   if (publishing === 'provider') {
     if (!providerFiles.source.name.startsWith(UNVERIFIED_PROVIDER_PREFIX)) {
       throw userError(
-        `❌ When publishing provider, provider name: "${providerFiles.source.name}" in provider.json must have prefix "${UNVERIFIED_PROVIDER_PREFIX}"`,
+        `When publishing provider, provider name: "${providerFiles.source.name}" in provider.json must have prefix "${UNVERIFIED_PROVIDER_PREFIX}"`,
         1
       );
     }

--- a/src/logic/publish.utils.test.ts
+++ b/src/logic/publish.utils.test.ts
@@ -210,7 +210,7 @@ describe('Publish logic utils', () => {
         })
       ).toThrow(
         new CLIError(
-          `Profile AST validation failed at $: expected 'astMetadata' in object, found: {}`
+          `❌ Error: Profile AST validation failed at $: expected 'astMetadata' in object, found: {}`
         )
       );
     });
@@ -229,7 +229,7 @@ describe('Publish logic utils', () => {
         })
       ).toThrow(
         new CLIError(
-          `Map AST validation failed at $: expected 'astMetadata' in object, found: {}`
+          `❌ Error: Map AST validation failed at $: expected 'astMetadata' in object, found: {}`
         )
       );
     });

--- a/src/logic/publish.utils.test.ts
+++ b/src/logic/publish.utils.test.ts
@@ -1,4 +1,3 @@
-import { CLIError } from '@oclif/errors';
 import {
   AstMetadata,
   MapDocumentNode,
@@ -209,9 +208,7 @@ describe('Publish logic utils', () => {
           superJson: mockSuperJson,
         })
       ).toThrow(
-        new CLIError(
-          `❌ Error: Profile AST validation failed at $: expected 'astMetadata' in object, found: {}`
-        )
+        `Profile AST validation failed at $: expected 'astMetadata' in object, found: {}`
       );
     });
 
@@ -228,9 +225,7 @@ describe('Publish logic utils', () => {
           superJson: mockSuperJson,
         })
       ).toThrow(
-        new CLIError(
-          `❌ Error: Map AST validation failed at $: expected 'astMetadata' in object, found: {}`
-        )
+        `Map AST validation failed at $: expected 'astMetadata' in object, found: {}`
       );
     });
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->

This PR unifies output of userError  - every output is prefixed with ❌ 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
