### PR TITLE
fix: install command sj load

### DIFF
--- a/src/commands/install.test.ts
+++ b/src/commands/install.test.ts
@@ -51,9 +51,50 @@ describe('Install CLI command', () => {
   });
 
   describe('when running install command', () => {
+    it('calls install profiles correctly - failed to install profile - does not continue with install', async () => {
+      mocked(detectSuperJson).mockResolvedValue(undefined);
+      mocked(initSuperface).mockResolvedValue(new SuperJson({}));
+      mocked(installProfiles).mockResolvedValue({ continueWithInstall: false });
+
+      const profileName = 'starwars/character-information';
+
+      await expect(
+        instance.execute({
+          logger,
+          pm,
+          userError,
+          args: { profileId: profileName },
+          flags: {
+            providers: [],
+          },
+        })
+      ).rejects.toThrow('EEXIT: 0');
+      expect(installProfiles).toHaveBeenCalledTimes(1);
+      expect(installProfiles).toHaveBeenCalledWith(
+        {
+          superPath: 'superface',
+          requests: [
+            {
+              kind: 'store',
+              profileId: ProfileId.fromScopeName(
+                'starwars',
+                'character-information'
+              ),
+            },
+          ],
+          options: {
+            tryToAuthenticate: true,
+            force: false,
+          },
+        },
+        expect.anything()
+      );
+    }, 10000);
+
     it('calls install profiles correctly - non existing super.json - create new one', async () => {
       mocked(detectSuperJson).mockResolvedValue(undefined);
       mocked(initSuperface).mockResolvedValue(new SuperJson({}));
+      mocked(installProfiles).mockResolvedValue({ continueWithInstall: true });
 
       const profileName = 'starwars/character-information';
 
@@ -93,6 +134,7 @@ describe('Install CLI command', () => {
     it('calls install profiles correctly', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
       mocked(isCompatible).mockResolvedValue(true);
+      mocked(installProfiles).mockResolvedValue({ continueWithInstall: true });
       const profileName = 'starwars/character-information';
 
       await expect(
@@ -130,6 +172,7 @@ describe('Install CLI command', () => {
 
     it('calls install profiles correctly without profileId', async () => {
       mocked(detectSuperJson).mockResolvedValue('.');
+      mocked(installProfiles).mockResolvedValue({ continueWithInstall: true });
 
       await expect(
         instance.execute({
@@ -270,6 +313,7 @@ describe('Install CLI command', () => {
       const profileId = ProfileId.fromId('starwars/character-information', {
         userError,
       });
+      mocked(installProfiles).mockResolvedValue({ continueWithInstall: true });
 
       await expect(
         instance.execute({
@@ -317,6 +361,8 @@ describe('Install CLI command', () => {
       const profileId = ProfileId.fromId('starwars/character-information', {
         userError,
       });
+
+      mocked(installProfiles).mockResolvedValue({ continueWithInstall: true });
 
       await expect(
         instance.execute({
@@ -392,6 +438,8 @@ describe('Install CLI command', () => {
       const profileId = ProfileId.fromId('starwars/character-information', {
         userError,
       });
+
+      mocked(installProfiles).mockResolvedValue({ continueWithInstall: true });
 
       await expect(
         instance.execute({

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -200,7 +200,7 @@ export default class Install extends Command {
       }
     }
 
-    await installProfiles(
+    const { continueWithInstall } = await installProfiles(
       {
         superPath,
         requests,
@@ -211,6 +211,10 @@ export default class Install extends Command {
       },
       { logger, userError }
     );
+    if (!continueWithInstall) {
+      this.exit();
+    }
+
     if (providers.length > 0) {
       logger.info('configuringProviders');
     }

--- a/src/logic/install.ts
+++ b/src/logic/install.ts
@@ -609,16 +609,19 @@ export async function installProfiles(
     options?: InstallOptions;
   },
   { logger, userError }: { logger: ILogger; userError: UserError }
-): Promise<void> {
+): Promise<{ continueWithInstall: boolean }> {
   const loadedResult = await SuperJson.load(joinPath(superPath, META_FILE));
   const superJson = loadedResult.match(
     v => v,
     err => {
       logger.error('errorMessage', err.formatLong());
 
-      return new SuperJson({});
+      return undefined;
     }
   );
+  if (!superJson) {
+    return { continueWithInstall: false };
+  }
 
   // gather requests if empty
   if (requests.length === 0) {
@@ -666,4 +669,6 @@ export async function installProfiles(
   } else {
     logger.info('noProfilesFound');
   }
+
+  return { continueWithInstall: true };
 }

--- a/src/logic/install.ts
+++ b/src/logic/install.ts
@@ -612,6 +612,8 @@ export async function installProfiles(
 ): Promise<{ continueWithInstall: boolean }> {
   const loadedResult = await SuperJson.load(joinPath(superPath, META_FILE));
   if (loadedResult.isErr()) {
+    logger.error('errorMessage', loadedResult.error.formatLong());
+
     return { continueWithInstall: false };
   }
   const superJson = loadedResult.value;

--- a/src/logic/install.ts
+++ b/src/logic/install.ts
@@ -611,17 +611,10 @@ export async function installProfiles(
   { logger, userError }: { logger: ILogger; userError: UserError }
 ): Promise<{ continueWithInstall: boolean }> {
   const loadedResult = await SuperJson.load(joinPath(superPath, META_FILE));
-  const superJson = loadedResult.match(
-    v => v,
-    err => {
-      logger.error('errorMessage', err.formatLong());
-
-      return undefined;
-    }
-  );
-  if (!superJson) {
+  if (loadedResult.isErr()) {
     return { continueWithInstall: false };
   }
+  const superJson = loadedResult.value;
 
   // gather requests if empty
   if (requests.length === 0) {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->
This PR fixes problems with loading invalid super.json during install command.

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
