### PR TITLE
Add `mapVariant` option to `configure` command

### DIFF
--- a/src/commands/configure.test.ts
+++ b/src/commands/configure.test.ts
@@ -241,5 +241,40 @@ describe('Configure CLI command', () => {
         expect.anything()
       );
     });
+
+    it('configures provider with mapVariant flag', async () => {
+      mocked(isValidDocumentName).mockReturnValue(true);
+      mocked(detectSuperJson).mockResolvedValue(superPath);
+      mocked(isCompatible).mockResolvedValue(true);
+
+      await expect(
+        instance.execute({
+          logger,
+          userError,
+          args: { providerName: provider },
+          flags: { profile: profileId.id, force: false, 'write-env': false, mapVariant: 'generated' },
+        })
+      ).resolves.toBeUndefined();
+
+      expect(detectSuperJson).toHaveBeenCalledTimes(1);
+
+      expect(installProvider).toHaveBeenCalledTimes(1);
+      expect(installProvider).toHaveBeenCalledWith(
+        {
+          superPath,
+          provider,
+          profileId,
+          defaults: undefined,
+          options: {
+            force: false,
+            localMap: undefined,
+            localProvider: undefined,
+            updateEnv: false,
+            mapVariant: 'generated'
+          },
+        },
+        expect.anything()
+      );
+    });
   });
 });

--- a/src/commands/configure.test.ts
+++ b/src/commands/configure.test.ts
@@ -252,7 +252,12 @@ describe('Configure CLI command', () => {
           logger,
           userError,
           args: { providerName: provider },
-          flags: { profile: profileId.id, force: false, 'write-env': false, mapVariant: 'generated' },
+          flags: {
+            profile: profileId.id,
+            force: false,
+            'write-env': false,
+            mapVariant: 'generated',
+          },
         })
       ).resolves.toBeUndefined();
 
@@ -270,11 +275,31 @@ describe('Configure CLI command', () => {
             localMap: undefined,
             localProvider: undefined,
             updateEnv: false,
-            mapVariant: 'generated'
+            mapVariant: 'generated',
           },
         },
         expect.anything()
       );
+    });
+
+    it('does not configure on invalid mapVariant flag', async () => {
+      mocked(isValidDocumentName).mockReturnValue(false);
+      await expect(
+        instance.execute({
+          logger,
+          userError,
+          args: {
+            providerName: provider,
+          },
+          flags: {
+            profile: 'test',
+            mapVariant: 'invalid!',
+          },
+        })
+      ).rejects.toThrow('Invalid map variant');
+
+      expect(detectSuperJson).not.toHaveBeenCalled();
+      expect(installProvider).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -1,5 +1,5 @@
 import { flags as oclifFlags } from '@oclif/command';
-import { isValidProviderName } from '@superfaceai/ast';
+import { isValidDocumentName, isValidProviderName } from '@superfaceai/ast';
 import { join as joinPath } from 'path';
 
 import { Command, Flags } from '../common/command.abstract';
@@ -51,7 +51,7 @@ export default class Configure extends Command {
     }),
     mapVariant: oclifFlags.string({
       description: 'Optional map variant',
-    })
+    }),
   };
 
   static examples = [
@@ -100,6 +100,10 @@ export default class Configure extends Command {
       throw userError(`Local path: "${flags.localProvider}" does not exist`, 1);
     }
 
+    if (flags.mapVariant && !isValidDocumentName(flags.mapVariant)) {
+      throw userError('Invalid map variant', 1);
+    }
+
     const profileId = ProfileId.fromId(flags.profile.trim(), { userError });
     const provider = args.providerName;
 
@@ -133,7 +137,7 @@ export default class Configure extends Command {
           localMap: flags.localMap,
           localProvider: flags.localProvider,
           updateEnv: flags['write-env'],
-          mapVariant: flags.mapVariant
+          mapVariant: flags.mapVariant,
         },
       },
       { logger, userError }

--- a/src/commands/configure.ts
+++ b/src/commands/configure.ts
@@ -49,6 +49,9 @@ export default class Configure extends Command {
     localMap: oclifFlags.string({
       description: 'Optional filepath to .suma map file',
     }),
+    mapVariant: oclifFlags.string({
+      description: 'Optional map variant',
+    })
   };
 
   static examples = [
@@ -57,6 +60,7 @@ export default class Configure extends Command {
     '$ superface configure twilio -p send-sms -f',
     '$ superface configure twilio -p send-sms --localProvider providers/twilio.provider.json',
     '$ superface configure twilio -p send-sms --localMap maps/send-sms.twilio.suma',
+    '$ superface configure twilio -p send-sms --mapVariant generated',
   ];
 
   async run(): Promise<void> {
@@ -129,6 +133,7 @@ export default class Configure extends Command {
           localMap: flags.localMap,
           localProvider: flags.localProvider,
           updateEnv: flags['write-env'],
+          mapVariant: flags.mapVariant
         },
       },
       { logger, userError }

--- a/src/common/document.test.ts
+++ b/src/common/document.test.ts
@@ -126,7 +126,7 @@ describe('Document functions', () => {
     });
 
     it('constructs profile provider settings with map variant correctly', async () => {
-      expect(constructProfileProviderSettings([{ providerName: 'first', mapVariant: 'generated'},{ providerName: 'second' }])).toEqual({
+      expect(constructProfileProviderSettings([{ providerName: 'first', mapVariant: 'generated' },{ providerName: 'second' }])).toEqual({
         first: { mapVariant: 'generated'},
         second: {},
       });

--- a/src/common/document.test.ts
+++ b/src/common/document.test.ts
@@ -119,8 +119,15 @@ describe('Document functions', () => {
 
   describe('when constructing profile provider settings', () => {
     it('constructs profile provider settings correctly', async () => {
-      expect(constructProfileProviderSettings(['first', 'second'])).toEqual({
+      expect(constructProfileProviderSettings([{ providerName: 'first' },{ providerName: 'second' }])).toEqual({
         first: {},
+        second: {},
+      });
+    });
+
+    it('constructs profile provider settings with map variant correctly', async () => {
+      expect(constructProfileProviderSettings([{ providerName: 'first', mapVariant: 'generated'},{ providerName: 'second' }])).toEqual({
+        first: { mapVariant: 'generated'},
         second: {},
       });
     });

--- a/src/common/document.ts
+++ b/src/common/document.ts
@@ -129,10 +129,13 @@ export const constructProfileSettings = (
  * @param providers - list of providers
  */
 export const constructProfileProviderSettings = (
-  providers: string[]
+  providers: {
+    providerName: string,
+    mapVariant?: string,
+  }[]
 ): Record<string, ProfileProviderEntry> =>
   providers.reduce<Record<string, ProfileProviderEntry>>((acc, provider) => {
-    acc[provider] = {};
+    acc[provider.providerName] = provider.mapVariant?{ mapVariant: provider.mapVariant}:{};
 
     return acc;
   }, {});

--- a/src/logic/configure.ts
+++ b/src/logic/configure.ts
@@ -71,6 +71,7 @@ export function handleProviderResponse(
       localMap?: string;
       localProvider?: string;
       force?: boolean;
+      mapVariant?: string;
     };
   },
   { logger }: { logger: ILogger }
@@ -104,7 +105,7 @@ export function handleProviderResponse(
   //constructProfileProviderSettings returns Record<string, ProfileProviderEntry>
   let settings = defaults
     ? { defaults }
-    : constructProfileProviderSettings([response.name])[response.name];
+    : constructProfileProviderSettings([{providerName: response.name, mapVariant: options?.mapVariant}])[response.name];
 
   if (options?.localMap) {
     if (typeof settings === 'string') {
@@ -162,6 +163,7 @@ export async function installProvider(
       localMap?: string;
       localProvider?: string;
       updateEnv?: boolean;
+      mapVariant?: string;
     };
   },
   { logger, userError }: { logger: ILogger; userError: UserError }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR adds `mapVariant` option to `configure` command. 

Example:
`superface configure twilio -p send-sms --mapVariant generated`


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Interaction designer creates maps with variant set to `generated` and we need to support configuration of such maps.

I did not implement validation of the `mapVariant` flag against Superface registry when running install command.

This is the error message user gets with first perform when invalid map variant is configured:
<img width="869" alt="image" src="https://user-images.githubusercontent.com/5206165/168320146-0c0c97af-8d5e-48d9-ae7d-635dc6bc4e30.png">


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
