### PR TITLE
chore: compile command refactor

### DIFF
--- a/src/commands/compile.test.ts
+++ b/src/commands/compile.test.ts
@@ -245,47 +245,40 @@ describe('Compile CLI command', () => {
         ).resolves.toBeUndefined();
 
         expect(compile).toHaveBeenCalledWith(
-          {
-            profiles: [
-              {
-                path: resolvePath(`../${mockProfile}.supr`),
-                id: ProfileId.fromId(mockProfile, { userError }),
-                maps: [
-                  {
-                    path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
-                    provider: mockProvider,
-                  },
-                  {
-                    path: resolvePath(
-                      `../${mockProfile}.${secondMockProvider}.suma`
-                    ),
-                    provider: secondMockProvider,
-                  },
-                ],
-              },
-              {
-                path: resolvePath(`../${secondMockProfile}.supr`),
-                id: ProfileId.fromId(secondMockProfile, { userError }),
-                maps: [
-                  {
-                    path: resolvePath(
-                      `../${secondMockProfile}.${thirdMockProvider}.suma`
-                    ),
-                    provider: thirdMockProvider,
-                  },
-                ],
-              },
-              {
-                path: undefined,
-                id: ProfileId.fromId('other/profile', { userError }),
-                maps: [],
-              },
-            ],
-            options: {
-              onlyMap: undefined,
-              onlyProfile: undefined,
+          [
+            {
+              path: resolvePath(`../${mockProfile}.supr`),
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'profile',
             },
-          },
+
+            {
+              path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
+              provider: mockProvider,
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'map',
+            },
+            {
+              path: resolvePath(`../${mockProfile}.${secondMockProvider}.suma`),
+              provider: secondMockProvider,
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'map',
+            },
+
+            {
+              path: resolvePath(`../${secondMockProfile}.supr`),
+              profileId: ProfileId.fromId(secondMockProfile, { userError }),
+              kind: 'profile',
+            },
+            {
+              path: resolvePath(
+                `../${secondMockProfile}.${thirdMockProvider}.suma`
+              ),
+              profileId: ProfileId.fromId(secondMockProfile, { userError }),
+              kind: 'map',
+              provider: thirdMockProvider,
+            },
+          ],
           expect.anything()
         );
 
@@ -306,44 +299,29 @@ describe('Compile CLI command', () => {
         ).resolves.toBeUndefined();
 
         expect(compile).toHaveBeenCalledWith(
-          {
-            profiles: [
-              {
-                path: resolvePath(`../${mockProfile}.supr`),
-                id: ProfileId.fromId(mockProfile, { userError }),
-                maps: [
-                  {
-                    path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
-                    provider: mockProvider,
-                  },
-                  {
-                    path: resolvePath(
-                      `../${mockProfile}.${secondMockProvider}.suma`
-                    ),
-                    provider: secondMockProvider,
-                  },
-                ],
-              },
-              {
-                path: resolvePath(`../${secondMockProfile}.supr`),
-                id: ProfileId.fromId(secondMockProfile, { userError }),
-                maps: [
-                  {
-                    path: resolvePath(
-                      `../${secondMockProfile}.${thirdMockProvider}.suma`
-                    ),
-                    provider: thirdMockProvider,
-                  },
-                ],
-              },
-              {
-                path: undefined,
-                id: ProfileId.fromId('other/profile', { userError }),
-                maps: [],
-              },
-            ],
-            options: { onlyMap: true, onlyProfile: undefined },
-          },
+          [
+            {
+              path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
+              provider: mockProvider,
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'map',
+            },
+            {
+              path: resolvePath(`../${mockProfile}.${secondMockProvider}.suma`),
+              provider: secondMockProvider,
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'map',
+            },
+
+            {
+              path: resolvePath(
+                `../${secondMockProfile}.${thirdMockProvider}.suma`
+              ),
+              provider: thirdMockProvider,
+              profileId: ProfileId.fromId(secondMockProfile, { userError }),
+              kind: 'map',
+            },
+          ],
           expect.anything()
         );
 
@@ -364,44 +342,18 @@ describe('Compile CLI command', () => {
         ).resolves.toBeUndefined();
 
         expect(compile).toHaveBeenCalledWith(
-          {
-            profiles: [
-              {
-                path: resolvePath(`../${mockProfile}.supr`),
-                id: ProfileId.fromId(mockProfile, { userError }),
-                maps: [
-                  {
-                    path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
-                    provider: mockProvider,
-                  },
-                  {
-                    path: resolvePath(
-                      `../${mockProfile}.${secondMockProvider}.suma`
-                    ),
-                    provider: secondMockProvider,
-                  },
-                ],
-              },
-              {
-                path: resolvePath(`../${secondMockProfile}.supr`),
-                id: ProfileId.fromId(secondMockProfile, { userError }),
-                maps: [
-                  {
-                    path: resolvePath(
-                      `../${secondMockProfile}.${thirdMockProvider}.suma`
-                    ),
-                    provider: thirdMockProvider,
-                  },
-                ],
-              },
-              {
-                path: undefined,
-                id: ProfileId.fromId('other/profile', { userError }),
-                maps: [],
-              },
-            ],
-            options: { onlyMap: undefined, onlyProfile: true },
-          },
+          [
+            {
+              path: resolvePath(`../${mockProfile}.supr`),
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'profile',
+            },
+            {
+              path: resolvePath(`../${secondMockProfile}.supr`),
+              profileId: ProfileId.fromId(secondMockProfile, { userError }),
+              kind: 'profile',
+            },
+          ],
           expect.anything()
         );
 
@@ -422,44 +374,39 @@ describe('Compile CLI command', () => {
         ).resolves.toBeUndefined();
 
         expect(compile).toHaveBeenCalledWith(
-          {
-            profiles: [
-              {
-                path: resolvePath(`../${mockProfile}.supr`),
-                id: ProfileId.fromId(mockProfile, { userError }),
-                maps: [
-                  {
-                    path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
-                    provider: mockProvider,
-                  },
-                  {
-                    path: resolvePath(
-                      `../${mockProfile}.${secondMockProvider}.suma`
-                    ),
-                    provider: secondMockProvider,
-                  },
-                ],
-              },
-              {
-                path: resolvePath(`../${secondMockProfile}.supr`),
-                id: ProfileId.fromId(secondMockProfile, { userError }),
-                maps: [
-                  {
-                    path: resolvePath(
-                      `../${secondMockProfile}.${thirdMockProvider}.suma`
-                    ),
-                    provider: thirdMockProvider,
-                  },
-                ],
-              },
-              {
-                path: undefined,
-                id: ProfileId.fromId('other/profile', { userError }),
-                maps: [],
-              },
-            ],
-            options: { onlyMap: undefined, onlyProfile: undefined },
-          },
+          [
+            {
+              path: resolvePath(`../${mockProfile}.supr`),
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'profile',
+            },
+
+            {
+              path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
+              provider: mockProvider,
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'map',
+            },
+            {
+              path: resolvePath(`../${mockProfile}.${secondMockProvider}.suma`),
+              provider: secondMockProvider,
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'map',
+            },
+            {
+              path: resolvePath(`../${secondMockProfile}.supr`),
+              profileId: ProfileId.fromId(secondMockProfile, { userError }),
+              kind: 'profile',
+            },
+            {
+              path: resolvePath(
+                `../${secondMockProfile}.${thirdMockProvider}.suma`
+              ),
+              profileId: ProfileId.fromId(secondMockProfile, { userError }),
+              kind: 'map',
+              provider: thirdMockProvider,
+            },
+          ],
           expect.anything()
         );
 
@@ -486,30 +433,26 @@ describe('Compile CLI command', () => {
         ).resolves.toBeUndefined();
 
         expect(compile).toHaveBeenCalledWith(
-          {
-            profiles: [
-              {
-                path: resolvePath(`../${mockProfile}.supr`),
-                id: ProfileId.fromId(mockProfile, { userError }),
-                maps: [
-                  {
-                    path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
-                    provider: mockProvider,
-                  },
-                  {
-                    path: resolvePath(
-                      `../${mockProfile}.${secondMockProvider}.suma`
-                    ),
-                    provider: secondMockProvider,
-                  },
-                ],
-              },
-            ],
-            options: {
-              onlyMap: undefined,
-              onlyProfile: undefined,
+          [
+            {
+              path: resolvePath(`../${mockProfile}.supr`),
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'profile',
             },
-          },
+            {
+              path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              provider: mockProvider,
+              kind: 'map',
+            },
+            {
+              path: resolvePath(`../${mockProfile}.${secondMockProvider}.suma`),
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+
+              provider: secondMockProvider,
+              kind: 'map',
+            },
+          ],
           expect.anything()
         );
 
@@ -534,27 +477,20 @@ describe('Compile CLI command', () => {
         ).resolves.toBeUndefined();
 
         expect(compile).toHaveBeenCalledWith(
-          {
-            profiles: [
-              {
-                path: resolvePath(`../${mockProfile}.supr`),
-                id: ProfileId.fromId(mockProfile, { userError }),
-                maps: [
-                  {
-                    path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
-                    provider: mockProvider,
-                  },
-                  {
-                    path: resolvePath(
-                      `../${mockProfile}.${secondMockProvider}.suma`
-                    ),
-                    provider: secondMockProvider,
-                  },
-                ],
-              },
-            ],
-            options: { onlyMap: true, onlyProfile: undefined },
-          },
+          [
+            {
+              path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
+              provider: mockProvider,
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'map',
+            },
+            {
+              path: resolvePath(`../${mockProfile}.${secondMockProvider}.suma`),
+              provider: secondMockProvider,
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'map',
+            },
+          ],
           expect.anything()
         );
 
@@ -579,27 +515,13 @@ describe('Compile CLI command', () => {
         ).resolves.toBeUndefined();
 
         expect(compile).toHaveBeenCalledWith(
-          {
-            profiles: [
-              {
-                path: resolvePath(`../${mockProfile}.supr`),
-                id: ProfileId.fromId(mockProfile, { userError }),
-                maps: [
-                  {
-                    path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
-                    provider: mockProvider,
-                  },
-                  {
-                    path: resolvePath(
-                      `../${mockProfile}.${secondMockProvider}.suma`
-                    ),
-                    provider: secondMockProvider,
-                  },
-                ],
-              },
-            ],
-            options: { onlyMap: undefined, onlyProfile: true },
-          },
+          [
+            {
+              path: resolvePath(`../${mockProfile}.supr`),
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'profile',
+            },
+          ],
           expect.anything()
         );
 
@@ -629,24 +551,19 @@ describe('Compile CLI command', () => {
         ).resolves.toBeUndefined();
 
         expect(compile).toHaveBeenCalledWith(
-          {
-            profiles: [
-              {
-                path: resolvePath(`../${mockProfile}.supr`),
-                id: ProfileId.fromId(mockProfile, { userError }),
-                maps: [
-                  {
-                    path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
-                    provider: mockProvider,
-                  },
-                ],
-              },
-            ],
-            options: {
-              onlyMap: undefined,
-              onlyProfile: undefined,
+          [
+            {
+              path: resolvePath(`../${mockProfile}.supr`),
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'profile',
             },
-          },
+            {
+              path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
+              provider: mockProvider,
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'map',
+            },
+          ],
           expect.anything()
         );
 
@@ -675,21 +592,14 @@ describe('Compile CLI command', () => {
         ).resolves.toBeUndefined();
 
         expect(compile).toHaveBeenCalledWith(
-          {
-            profiles: [
-              {
-                path: resolvePath(`../${mockProfile}.supr`),
-                id: ProfileId.fromId(mockProfile, { userError }),
-                maps: [
-                  {
-                    path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
-                    provider: mockProvider,
-                  },
-                ],
-              },
-            ],
-            options: { onlyMap: true, onlyProfile: undefined },
-          },
+          [
+            {
+              path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
+              provider: mockProvider,
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'map',
+            },
+          ],
           expect.anything()
         );
 
@@ -718,21 +628,13 @@ describe('Compile CLI command', () => {
         ).resolves.toBeUndefined();
 
         expect(compile).toHaveBeenCalledWith(
-          {
-            profiles: [
-              {
-                path: resolvePath(`../${mockProfile}.supr`),
-                id: ProfileId.fromId(mockProfile, { userError }),
-                maps: [
-                  {
-                    path: resolvePath(`../${mockProfile}.${mockProvider}.suma`),
-                    provider: mockProvider,
-                  },
-                ],
-              },
-            ],
-            options: { onlyMap: undefined, onlyProfile: true },
-          },
+          [
+            {
+              path: resolvePath(`../${mockProfile}.supr`),
+              profileId: ProfileId.fromId(mockProfile, { userError }),
+              kind: 'profile',
+            },
+          ],
           expect.anything()
         );
 

--- a/src/commands/compile.ts
+++ b/src/commands/compile.ts
@@ -13,7 +13,7 @@ import { META_FILE } from '../common/document';
 import { UserError } from '../common/error';
 import { ILogger } from '../common/log';
 import { ProfileId } from '../common/profile';
-import { compile, MapToCompile, ProfileToCompile } from '../logic/compile';
+import { compile, FileToCompile } from '../logic/compile';
 import { detectSuperJson } from '../logic/install';
 
 export default class Compile extends Command {
@@ -54,7 +54,7 @@ export default class Compile extends Command {
     '$ superface compile --profileId starwars/character-information --profile',
     '$ superface compile --profileId starwars/character-information --profile -q',
     '$ superface compile --profileId starwars/character-information --providerName swapi --onlyMap',
-    '$ superface compile --profileId starwars/character-information --providerName swapi --onlyMap --onlyProfile',
+    '$ superface compile --profileId starwars/character-information --providerName swapi --onlyProfile',
   ];
 
   async run(): Promise<void> {
@@ -138,64 +138,65 @@ export default class Compile extends Command {
       }
     }
 
-    const profiles: ProfileToCompile[] = [];
+    const files: FileToCompile[] = [];
 
     //Compile every local map/profile in super.json
     if (!flags.profileId && !flags.providerName) {
       for (const [profile, profileSettings] of Object.entries(
         normalized.profiles
       )) {
-        const maps: MapToCompile[] = [];
+        const profileId = ProfileId.fromId(profile, { userError });
+        if ('file' in profileSettings) {
+          files.push({
+            path: resolvePath(dirname(superJsonPath), profileSettings.file),
+            kind: 'profile',
+            profileId,
+          });
+        }
         for (const [provider, profileProviderSettings] of Object.entries(
           profileSettings.providers
         )) {
           if ('file' in profileProviderSettings) {
-            maps.push({
+            files.push({
               path: resolvePath(
                 dirname(superJsonPath),
                 profileProviderSettings.file
               ),
+              kind: 'map',
+              profileId,
               provider,
             });
           }
         }
-        profiles.push({
-          path:
-            'file' in profileSettings
-              ? resolvePath(dirname(superJsonPath), profileSettings.file)
-              : undefined,
-          maps,
-          id: ProfileId.fromId(profile, { userError }),
-        });
       }
     }
 
     //Compile single local profile and its local maps
     if (flags.profileId && !flags.providerName) {
       const profileSettings = normalized.profiles[flags.profileId];
-      const maps: MapToCompile[] = [];
-
+      const profileId = ProfileId.fromId(flags.profileId, { userError });
+      if ('file' in profileSettings) {
+        files.push({
+          path: resolvePath(dirname(superJsonPath), profileSettings.file),
+          kind: 'profile',
+          profileId,
+        });
+      }
       for (const [provider, profileProviderSettings] of Object.entries(
         profileSettings.providers
       )) {
         if ('file' in profileProviderSettings) {
-          maps.push({
+          files.push({
             path: resolvePath(
               dirname(superJsonPath),
               profileProviderSettings.file
             ),
+            profileId,
+            kind: 'map',
             provider,
           });
         }
       }
-      profiles.push({
-        path:
-          'file' in profileSettings
-            ? resolvePath(dirname(superJsonPath), profileSettings.file)
-            : undefined,
-        maps,
-        id: ProfileId.fromId(flags.profileId, { userError }),
-      });
     }
 
     //Compile single local profile and single local map
@@ -203,37 +204,39 @@ export default class Compile extends Command {
       const profileSettings = normalized.profiles[flags.profileId];
       const profileProviderSettings =
         profileSettings.providers[flags.providerName];
-      const maps: MapToCompile[] = [];
 
+      const profileId = ProfileId.fromId(flags.profileId, { userError });
+
+      if ('file' in profileSettings) {
+        files.push({
+          path: resolvePath(dirname(superJsonPath), profileSettings.file),
+          kind: 'profile',
+          profileId,
+        });
+      }
       if ('file' in profileProviderSettings) {
-        maps.push({
+        files.push({
           path: resolvePath(
             dirname(superJsonPath),
             profileProviderSettings.file
           ),
+          kind: 'map',
+          profileId,
           provider: flags.providerName,
         });
       }
-      profiles.push({
-        path:
-          'file' in profileSettings
-            ? resolvePath(dirname(superJsonPath), profileSettings.file)
-            : undefined,
-        maps,
-        id: ProfileId.fromId(flags.profileId, { userError }),
-      });
     }
 
-    await compile(
-      {
-        profiles,
-        options: {
-          onlyMap: flags.onlyMap,
-          onlyProfile: flags.onlyProfile,
-        },
-      },
-      { logger, userError }
-    );
+    let filteredFiles: FileToCompile[];
+    if (flags.onlyProfile === true) {
+      filteredFiles = files.filter(file => file.kind === 'profile');
+    } else if (flags.onlyMap === true) {
+      filteredFiles = files.filter(file => file.kind === 'map');
+    } else {
+      filteredFiles = files;
+    }
+
+    await compile(filteredFiles, { logger, userError });
 
     logger.success('compiledSuccessfully');
   }

--- a/src/logic/compile.test.ts
+++ b/src/logic/compile.test.ts
@@ -14,7 +14,7 @@ import { OutputStream } from '../common/output-stream';
 import { ProfileId } from '../common/profile';
 import { mockMapDocumentNode } from '../test/map-document-node';
 import { mockProfileDocumentNode } from '../test/profile-document-node';
-import { compile, ProfileToCompile } from './compile';
+import { compile, FileToCompile } from './compile';
 
 jest.mock('../common/io', () => ({
   readFile: jest.fn(),
@@ -69,36 +69,58 @@ describe('Compile CLI logic', () => {
     const mockProfileContent = 'mock-profile-content';
     const mockMapContent = 'mock-map-content';
 
-    const profiles: ProfileToCompile[] = [
+    const files: FileToCompile[] = [
       {
         path: 'first/profile.supr',
-        id: ProfileId.fromScopeName('first', 'profile'),
-        maps: [
-          { path: 'first/profile/first/map.suma', provider: 'first' },
-          { path: 'first/profile/second/map.suma', provider: 'second' },
-        ],
+        profileId: ProfileId.fromScopeName('first', 'profile'),
+        kind: 'profile',
+      },
+      {
+        profileId: ProfileId.fromScopeName('first', 'profile'),
+        kind: 'map',
+        path: 'first/profile/first/map.suma',
+        provider: 'first',
+      },
+      {
+        profileId: ProfileId.fromScopeName('first', 'profile'),
+        kind: 'map',
+        path: 'first/profile/second/map.suma',
+        provider: 'second',
       },
       {
         path: 'second/profile.supr',
-        id: ProfileId.fromScopeName('second', 'profile'),
-        maps: [
-          { path: 'second/profile/first/map.suma', provider: 'first' },
-          { path: 'second/profile/second/map.suma', provider: 'second' },
-        ],
+        profileId: ProfileId.fromScopeName('second', 'profile'),
+        kind: 'profile',
+      },
+      {
+        path: 'second/profile/first/map.suma',
+        provider: 'first',
+        profileId: ProfileId.fromScopeName('second', 'profile'),
+        kind: 'map',
+      },
+      {
+        path: 'second/profile/second/map.suma',
+        provider: 'second',
+        profileId: ProfileId.fromScopeName('second', 'profile'),
+        kind: 'map',
       },
       {
         path: 'third/profile.supr.ast.json',
-        id: ProfileId.fromScopeName('third', 'profile'),
-        maps: [
-          { path: 'third/profile/first/map.suma.ast.json', provider: 'first' },
-        ],
+        profileId: ProfileId.fromScopeName('third', 'profile'),
+        kind: 'profile',
       },
       {
-        path: undefined,
-        id: ProfileId.fromScopeName('remote', 'profile'),
-        maps: [
-          { path: 'remote/profile/first/map.suma.ast.json', provider: 'first' },
-        ],
+        path: 'third/profile/first/map.suma.ast.json',
+        provider: 'first',
+        profileId: ProfileId.fromScopeName('third', 'profile'),
+        kind: 'map',
+      },
+
+      {
+        profileId: ProfileId.fromScopeName('remote', 'profile'),
+        path: 'remote/profile/first/map.suma.ast.json',
+        provider: 'first',
+        kind: 'map',
       },
     ];
 
@@ -116,16 +138,16 @@ describe('Compile CLI logic', () => {
       });
 
       await expect(
-        compile({ profiles }, { logger, userError })
+        compile(files, { logger, userError })
       ).resolves.toBeUndefined();
       expect(parseProfileSpy).toHaveBeenCalledTimes(3);
       expect(parseProfileSpy).toHaveBeenNthCalledWith(
         1,
-        new Source(mockProfileContent, profiles[0].path)
+        new Source(mockProfileContent, files[0].path)
       );
       expect(parseProfileSpy).toHaveBeenNthCalledWith(
         2,
-        new Source(mockProfileContent, profiles[1].path)
+        new Source(mockProfileContent, files[3].path)
       );
       expect(parseProfileSpy).toHaveBeenNthCalledWith(
         3,
@@ -138,27 +160,27 @@ describe('Compile CLI logic', () => {
 
       expect(parseMapSpy).toHaveBeenNthCalledWith(
         1,
-        new Source(mockMapContent, profiles[0].maps[0].path)
+        new Source(mockMapContent, files[1].path)
       );
       expect(parseMapSpy).toHaveBeenNthCalledWith(
         2,
-        new Source(mockMapContent, profiles[0].maps[1].path)
+        new Source(mockMapContent, files[2].path)
       );
       expect(parseMapSpy).toHaveBeenNthCalledWith(
         3,
-        new Source(mockMapContent, profiles[1].maps[0].path)
+        new Source(mockMapContent, files[4].path)
       );
       expect(parseMapSpy).toHaveBeenNthCalledWith(
         4,
-        new Source(mockMapContent, profiles[1].maps[1].path)
+        new Source(mockMapContent, files[5].path)
       );
       expect(parseMapSpy).toHaveBeenNthCalledWith(
         5,
-        new Source(mockMapContent, profiles[2].maps[0].path)
+        new Source(mockMapContent, 'third/profile/first/map.suma')
       );
       expect(parseMapSpy).toHaveBeenNthCalledWith(
         6,
-        new Source(mockMapContent, profiles[3].maps[0].path)
+        new Source(mockMapContent, 'remote/profile/first/map.suma')
       );
       expect(writeOnceSpy).toHaveBeenCalledWith(
         'first/profile.supr.ast.json',
@@ -201,134 +223,24 @@ describe('Compile CLI logic', () => {
       );
     });
 
-    it('compiles only maps', async () => {
-      mocked(exists).mockResolvedValue(true);
-      mocked(readFile).mockImplementation(path => {
-        if (path.toString().endsWith('.suma')) {
-          return Promise.resolve(mockMapContent);
-        }
-
-        return Promise.resolve(mockProfileContent);
-      });
-
-      await expect(
-        compile({ profiles, options: { onlyMap: true } }, { logger, userError })
-      ).resolves.toBeUndefined();
-      expect(parseProfileSpy).not.toHaveBeenCalled();
-
-      expect(parseMapSpy).toHaveBeenNthCalledWith(
-        1,
-        new Source(mockMapContent, profiles[0].maps[0].path)
-      );
-      expect(parseMapSpy).toHaveBeenNthCalledWith(
-        2,
-        new Source(mockMapContent, profiles[0].maps[1].path)
-      );
-      expect(parseMapSpy).toHaveBeenNthCalledWith(
-        3,
-        new Source(mockMapContent, profiles[1].maps[0].path)
-      );
-      expect(parseMapSpy).toHaveBeenNthCalledWith(
-        4,
-        new Source(mockMapContent, profiles[1].maps[1].path)
-      );
-      expect(parseMapSpy).toHaveBeenNthCalledWith(
-        5,
-        new Source(mockMapContent, profiles[2].maps[0].path)
-      );
-      expect(writeOnceSpy).toHaveBeenCalledWith(
-        'first/profile/first/map.suma.ast.json',
-        JSON.stringify(mockMap, undefined, 2)
-      );
-      expect(writeOnceSpy).toHaveBeenCalledWith(
-        'first/profile/second/map.suma.ast.json',
-        JSON.stringify(mockMap, undefined, 2)
-      );
-
-      expect(writeOnceSpy).toHaveBeenCalledWith(
-        'second/profile/first/map.suma.ast.json',
-        JSON.stringify(mockMap, undefined, 2)
-      );
-      expect(writeOnceSpy).toHaveBeenCalledWith(
-        'second/profile/second/map.suma.ast.json',
-        JSON.stringify(mockMap, undefined, 2)
-      );
-
-      expect(writeOnceSpy).toHaveBeenCalledWith(
-        'third/profile/first/map.suma.ast.json',
-        JSON.stringify(mockMap, undefined, 2)
-      );
-    });
-
-    it('compiles only profiles', async () => {
-      mocked(exists).mockResolvedValue(true);
-      mocked(readFile).mockImplementation(path => {
-        if (path.toString().endsWith('.suma')) {
-          return Promise.resolve(mockMapContent);
-        }
-
-        return Promise.resolve(mockProfileContent);
-      });
-
-      await expect(
-        compile(
-          { profiles, options: { onlyProfile: true } },
-          { logger, userError }
-        )
-      ).resolves.toBeUndefined();
-      expect(parseProfileSpy).toHaveBeenNthCalledWith(
-        1,
-        new Source(mockProfileContent, profiles[0].path)
-      );
-      expect(parseProfileSpy).toHaveBeenNthCalledWith(
-        2,
-        new Source(mockProfileContent, profiles[1].path)
-      );
-      expect(parseProfileSpy).toHaveBeenNthCalledWith(
-        3,
-        new Source(
-          mockProfileContent,
-          // reads source
-          'third/profile.supr'
-        )
-      );
-
-      expect(parseMapSpy).not.toHaveBeenCalled();
-      expect(writeOnceSpy).toHaveBeenCalledWith(
-        'first/profile.supr.ast.json',
-        JSON.stringify(mockProfile, undefined, 2)
-      );
-      expect(writeOnceSpy).toHaveBeenCalledWith(
-        'second/profile.supr.ast.json',
-        JSON.stringify(mockProfile, undefined, 2)
-      );
-      expect(writeOnceSpy).toHaveBeenCalledWith(
-        'third/profile.supr.ast.json',
-        JSON.stringify(mockProfile, undefined, 2)
-      );
-    });
-
     it('throws on profile file with unsupported extension', async () => {
       mocked(exists).mockResolvedValue(false);
 
       await expect(
         compile(
-          {
-            profiles: [
-              {
-                path: 'profile.ts',
-                id: ProfileId.fromScopeName('first', 'profile'),
-                maps: [],
-              },
-            ],
-          },
+          [
+            {
+              path: 'profile.ts',
+              profileId: ProfileId.fromScopeName('first', 'profile'),
+              kind: 'profile',
+            },
+          ],
           { logger, userError }
         )
       ).rejects.toThrow(
         'Path: "profile.ts" uses unsupported extension. Please use file with ".supr" extension.'
       );
       expect(parseProfileSpy).not.toHaveBeenCalled();
-
       expect(parseMapSpy).not.toHaveBeenCalled();
       expect(writeOnceSpy).not.toHaveBeenCalled();
     });
@@ -336,9 +248,7 @@ describe('Compile CLI logic', () => {
     it('throws when profile file does not exist', async () => {
       mocked(exists).mockResolvedValue(false);
 
-      await expect(
-        compile({ profiles }, { logger, userError })
-      ).rejects.toThrow(
+      await expect(compile(files, { logger, userError })).rejects.toThrow(
         'Path: "first/profile.supr" for profile first/profile does not exist'
       );
       expect(parseProfileSpy).not.toHaveBeenCalled();
@@ -348,32 +258,28 @@ describe('Compile CLI logic', () => {
     });
 
     it('throws on map file with unsupported extension', async () => {
-      mocked(exists).mockResolvedValue(true);
+      mocked(exists).mockResolvedValue(false);
       mocked(readFile).mockImplementation(() => {
         return Promise.resolve(mockProfileContent);
       });
 
       await expect(
         compile(
-          {
-            profiles: [
-              {
-                path: 'profile.supr',
-                id: ProfileId.fromScopeName('first', 'profile'),
-                maps: [{ path: 'profile/first/map.ts', provider: 'first' }],
-              },
-            ],
-          },
+          [
+            {
+              profileId: ProfileId.fromScopeName('first', 'profile'),
+              path: 'profile/first/map.ts',
+              provider: 'first',
+              kind: 'map',
+            },
+          ],
           { logger, userError }
         )
       ).rejects.toThrow(
         'Path: "profile/first/map.ts" uses unsupported extension. Please use file with ".suma" extension.'
       );
-      expect(parseProfileSpy).toHaveBeenCalledWith(
-        new Source(mockProfileContent, 'profile.supr')
-      );
       expect(parseMapSpy).not.toHaveBeenCalled();
-      expect(writeOnceSpy).toHaveBeenCalledTimes(1);
+      expect(writeOnceSpy).not.toHaveBeenCalled();
     });
 
     it('throws when map file does not exist', async () => {
@@ -386,13 +292,11 @@ describe('Compile CLI logic', () => {
         return Promise.resolve(mockProfileContent);
       });
 
-      await expect(
-        compile({ profiles }, { logger, userError })
-      ).rejects.toThrow(
+      await expect(compile(files, { logger, userError })).rejects.toThrow(
         'Path: "first/profile/first/map.suma" for map first/profile.first does not exist'
       );
       expect(parseProfileSpy).toHaveBeenCalledWith(
-        new Source(mockProfileContent, profiles[0].path)
+        new Source(mockProfileContent, files[0].path)
       );
 
       expect(parseMapSpy).not.toHaveBeenCalled();
@@ -419,17 +323,19 @@ describe('Compile CLI logic', () => {
 
       await expect(
         compile(
-          {
-            profiles: [
-              {
-                path: 'first/profile.supr',
-                id: ProfileId.fromScopeName('first', 'profile'),
-                maps: [
-                  { path: 'first/profile/first/map.suma', provider: 'first' },
-                ],
-              },
-            ],
-          },
+          [
+            {
+              path: 'first/profile.supr',
+              profileId: ProfileId.fromScopeName('first', 'profile'),
+              kind: 'profile',
+            },
+            {
+              profileId: ProfileId.fromScopeName('first', 'profile'),
+              kind: 'map',
+              path: 'first/profile/first/map.suma',
+              provider: 'first',
+            },
+          ],
           { logger, userError }
         )
       ).resolves.toBeUndefined();

--- a/src/logic/compile.ts
+++ b/src/logic/compile.ts
@@ -11,130 +11,88 @@ import { ILogger } from '../common/log';
 import { OutputStream } from '../common/output-stream';
 import { ProfileId } from '../common/profile';
 
-export type MapToCompile = { provider: string; path: string };
-export type ProfileToCompile = {
-  id: ProfileId;
-  maps: MapToCompile[];
-  path?: string;
-};
+export type FileToCompile =
+  | { kind: 'map'; profileId: ProfileId; provider: string; path: string }
+  | { kind: 'profile'; profileId: ProfileId; path: string };
 
 export async function compile(
-  {
-    profiles,
-    options,
-  }: {
-    profiles: ProfileToCompile[];
-    options?: {
-      onlyMap?: boolean;
-      onlyProfile?: boolean;
-    };
-  },
+  files: FileToCompile[],
   { logger, userError }: { logger: ILogger; userError: UserError }
 ): Promise<void> {
-  for (const profile of profiles) {
-    //Compile profile
-    if (!options?.onlyMap && profile.path !== undefined) {
-      let profileSourcePath: string, profileAstPath: string;
-      //We assume source and build files living next to each other
-      if (profile.path.endsWith(EXTENSIONS.profile.source)) {
-        profileSourcePath = profile.path;
-        profileAstPath = profile.path.replace(
-          EXTENSIONS.profile.source,
-          EXTENSIONS.profile.build
-        );
-      } else if (profile.path.endsWith(EXTENSIONS.profile.build)) {
-        profileAstPath = profile.path;
-        profileSourcePath = profile.path.replace(
-          EXTENSIONS.profile.build,
-          EXTENSIONS.profile.source
+  for (const file of files) {
+    let sourcePath: string, astPath: string;
+    //We assume source and build files living next to each other
+    if (file.path.endsWith(EXTENSIONS[file.kind].source)) {
+      sourcePath = file.path;
+      astPath = file.path.replace(
+        EXTENSIONS[file.kind].source,
+        EXTENSIONS[file.kind].build
+      );
+    } else if (file.path.endsWith(EXTENSIONS[file.kind].build)) {
+      astPath = file.path;
+      sourcePath = file.path.replace(
+        EXTENSIONS[file.kind].build,
+        EXTENSIONS[file.kind].source
+      );
+    } else {
+      throw userError(
+        `Path: "${
+          file.path
+        }" uses unsupported extension. Please use file with "${
+          EXTENSIONS[file.kind].source
+        }" extension.`,
+        1
+      );
+    }
+
+    if (file.kind === 'profile') {
+      logger.info('compileProfile', file.profileId.id.toString());
+    } else {
+      logger.info('compileMap', file.profileId.id.toString(), file.provider);
+    }
+    if (!(await exists(sourcePath))) {
+      if (file.kind === 'profile') {
+        throw userError(
+          `Path: "${sourcePath}" for profile ${file.profileId.id.toString()} does not exist`,
+          1
         );
       } else {
         throw userError(
-          `Path: "${profile.path}" uses unsupported extension. Please use file with "${EXTENSIONS.profile.source}" extension.`,
+          `Path: "${sourcePath}" for map ${file.profileId.id.toString()}.${
+            file.provider
+          } does not exist`,
           1
-        );
-      }
-      logger.info('compileProfile', profile.id.toString());
-      if (!(await exists(profileSourcePath))) {
-        throw userError(
-          `Path: "${profileSourcePath}" for profile ${profile.id.toString()} does not exist`,
-          1
-        );
-      }
-      const source = await readFile(profileSourcePath, { encoding: 'utf-8' });
-      let profileAst: ProfileDocumentNode | undefined;
-      try {
-        profileAst = parseProfile(new Source(source, profileSourcePath));
-      } catch (error) {
-        logger.error(
-          'profileCompilationFailed',
-          profile.id.toString(),
-          profileSourcePath,
-          error
-        );
-      }
-
-      if (profileAst !== undefined) {
-        await OutputStream.writeOnce(
-          profileAstPath,
-          JSON.stringify(profileAst, undefined, 2)
         );
       }
     }
-    //Compile maps
-    if (!options?.onlyProfile) {
-      for (const map of profile.maps) {
-        logger.info('compileMap', profile.id.toString(), map.provider);
-
-        let mapSourcePath: string, mapAstPath: string;
-        //We assume .suma and .suma.ast.json files living next to each other
-        if (map.path.endsWith(EXTENSIONS.map.source)) {
-          mapSourcePath = map.path;
-          mapAstPath = map.path.replace(
-            EXTENSIONS.map.source,
-            EXTENSIONS.map.build
-          );
-        } else if (map.path.endsWith(EXTENSIONS.map.build)) {
-          mapAstPath = map.path;
-          mapSourcePath = map.path.replace(
-            EXTENSIONS.map.build,
-            EXTENSIONS.map.source
-          );
-        } else {
-          throw userError(
-            `Path: "${map.path}" uses unsupported extension. Please use file with "${EXTENSIONS.map.source}" extension.`,
-            1
-          );
-        }
-        if (!(await exists(mapSourcePath))) {
-          throw userError(
-            `Path: "${mapSourcePath}" for map ${profile.id.toString()}.${
-              map.provider
-            } does not exist`,
-            1
-          );
-        }
-        const source = await readFile(mapSourcePath, { encoding: 'utf-8' });
-        let mapAst: MapDocumentNode | undefined;
-        try {
-          mapAst = parseMap(new Source(source, map.path));
-        } catch (error) {
-          logger.error(
-            'mapCompilationFailed',
-            profile.id.toString(),
-            map.provider,
-            mapSourcePath,
-            error
-          );
-        }
-
-        if (mapAst !== undefined) {
-          await OutputStream.writeOnce(
-            mapAstPath,
-            JSON.stringify(mapAst, undefined, 2)
-          );
-        }
+    const source = await readFile(sourcePath, { encoding: 'utf-8' });
+    let ast: ProfileDocumentNode | MapDocumentNode | undefined;
+    try {
+      ast =
+        file.kind === 'map'
+          ? parseMap(new Source(source, sourcePath))
+          : parseProfile(new Source(source, sourcePath));
+    } catch (error) {
+      if (file.kind === 'profile') {
+        logger.error(
+          'profileCompilationFailed',
+          file.profileId.id.toString(),
+          sourcePath,
+          error
+        );
+      } else {
+        logger.error(
+          'mapCompilationFailed',
+          file.profileId.id.toString(),
+          file.provider,
+          sourcePath,
+          error
+        );
       }
+    }
+
+    if (ast !== undefined) {
+      await OutputStream.writeOnce(astPath, JSON.stringify(ast, undefined, 2));
     }
   }
 }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This pr simplifies compile command logic. Instead of nested object array, flat array is passed (representing files to be compiled). `Kind` of each element is used to decide if we are compiling profile or map. Pr also simplifies filtering of map/profiles when onlyMaps/onlyProfiles flag is used. This does not change API for user. 

fixes: https://github.com/superfaceai/cli/issues/222
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
