### PR TITLE
chore: improve lint type safety

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -180,6 +180,7 @@ export default class Lint extends Command {
 
     const result = await lint(superJson, superJsonPath, profiles, {
       logger,
+      userError,
     });
 
     if (flags.outputFormat === 'long' || flags.outputFormat === 'short') {

--- a/src/logic/lint.test.ts
+++ b/src/logic/lint.test.ts
@@ -501,7 +501,7 @@ describe('Lint logic', () => {
         .mockReturnValueOnce(mockMapDocumentMatching);
 
       await expect(
-        lint(mockSuperJson, '', mockProfiles, { logger })
+        lint(mockSuperJson, '', mockProfiles, { logger, userError })
       ).resolves.toEqual({
         reports: [
           {
@@ -584,7 +584,7 @@ describe('Lint logic', () => {
         .mockResolvedValueOnce(mockMapDocumentMatching);
 
       await expect(
-        lint(mockSuperJson, '', mockProfiles, { logger })
+        lint(mockSuperJson, '', mockProfiles, { logger, userError })
       ).resolves.toEqual({
         reports: [
           {
@@ -666,7 +666,7 @@ describe('Lint logic', () => {
       jest.mocked(fetchProfileAST).mockResolvedValue(mockProfileDocument);
 
       await expect(
-        lint(mockSuperJson, '', mockProfiles, { logger })
+        lint(mockSuperJson, '', mockProfiles, { logger, userError })
       ).resolves.toEqual({
         reports: [
           {
@@ -717,12 +717,9 @@ describe('Lint logic', () => {
     });
 
     it('returns correct counts, corrupted profile', async () => {
-      const mockSyntaxErr: SyntaxError = {
-        source: new Source('test'),
-        formatHints: () => '',
-        formatVisualization: () => '',
-        hints: [],
-        location: {
+      const mockSyntaxErr = new SyntaxError(
+        new Source('test'),
+        {
           start: {
             line: 0,
             column: 0,
@@ -734,11 +731,8 @@ describe('Lint logic', () => {
             charIndex: 0,
           },
         },
-        category: SyntaxErrorCategory.PARSER,
-        detail: '',
-        format: () => 'detail',
-        message: 'message',
-      };
+        SyntaxErrorCategory.PARSER
+      );
 
       const profile = ProfileId.fromScopeName(
         'starwars',
@@ -771,37 +765,11 @@ describe('Lint logic', () => {
       });
 
       await expect(
-        lint(mockSuperJson, '', mockProfiles, { logger })
+        lint(mockSuperJson, '', mockProfiles, { logger, userError })
       ).resolves.toEqual({
         reports: [
           {
-            errors: [
-              {
-                category: 'Parser',
-                detail: '',
-                format: expect.any(Function),
-                formatHints: expect.any(Function),
-                formatVisualization: expect.any(Function),
-                hints: [],
-                location: {
-                  end: {
-                    charIndex: 0,
-                    column: 0,
-                    line: 0,
-                  },
-                  start: {
-                    charIndex: 0,
-                    column: 0,
-                    line: 0,
-                  },
-                },
-                message: 'message',
-                source: new Source('test', undefined, {
-                  column: 0,
-                  line: 0,
-                }),
-              },
-            ],
+            errors: [mockSyntaxErr],
             kind: 'file',
             path: 'mockProfilePath',
             warnings: [],
@@ -812,12 +780,9 @@ describe('Lint logic', () => {
     });
 
     it('returns correct counts, corrupted map', async () => {
-      const mockSyntaxErr: SyntaxError = {
-        source: new Source('test'),
-        formatHints: () => '',
-        formatVisualization: () => '',
-        hints: [],
-        location: {
+      const mockSyntaxErr = new SyntaxError(
+        new Source('test'),
+        {
           start: {
             line: 0,
             column: 0,
@@ -829,11 +794,8 @@ describe('Lint logic', () => {
             charIndex: 0,
           },
         },
-        category: SyntaxErrorCategory.PARSER,
-        detail: '',
-        format: () => 'detail',
-        message: 'message',
-      };
+        SyntaxErrorCategory.PARSER
+      );
 
       const profile = ProfileId.fromScopeName(
         'starwars',
@@ -867,7 +829,7 @@ describe('Lint logic', () => {
       });
 
       await expect(
-        lint(mockSuperJson, '', mockProfiles, { logger })
+        lint(mockSuperJson, '', mockProfiles, { logger, userError })
       ).resolves.toEqual({
         reports: [
           {
@@ -877,33 +839,7 @@ describe('Lint logic', () => {
             warnings: [],
           },
           {
-            errors: [
-              {
-                category: 'Parser',
-                detail: '',
-                format: expect.any(Function),
-                formatHints: expect.any(Function),
-                formatVisualization: expect.any(Function),
-                hints: [],
-                location: {
-                  end: {
-                    charIndex: 0,
-                    column: 0,
-                    line: 0,
-                  },
-                  start: {
-                    charIndex: 0,
-                    column: 0,
-                    line: 0,
-                  },
-                },
-                message: 'message',
-                source: new Source('test', undefined, {
-                  column: 0,
-                  line: 0,
-                }),
-              },
-            ],
+            errors: [mockSyntaxErr],
             kind: 'file',
             path: 'mockMapPath',
             warnings: [],


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR fixes: https://github.com/superfaceai/cli/issues/238 by adding instances check and fallback to userError



## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
