### PR TITLE
feat: prepare mock map test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - New `prepare:test` command
+- New `prepare:mock-map-test` command
 
 ## [2.0.0] - 2022-08-15
 ### Changed

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ npx @superfaceai/cli install [profileId eg. communication/send-email]
 * [`superface logout`](#superface-logout)
 * [`superface prepare:map PROFILEID PROVIDERNAME`](#superface-preparemap-profileid-providername)
 * [`superface prepare:mock-map PROFILEID`](#superface-preparemock-map-profileid)
+* [`superface prepare:mock-map-test PROFILEID`](#superface-preparemock-map-test-profileid)
 * [`superface prepare:test PROFILEID PROVIDERNAME`](#superface-preparetest-profileid-providername)
 * [`superface publish DOCUMENTTYPE`](#superface-publish-documenttype)
 * [`superface whoami`](#superface-whoami)
@@ -76,35 +77,38 @@ Checks all maps, profiles and providers locally linked in super.json. Also can b
 
 ```
 USAGE
-  $ superface check
+  $ superface check [-q] [--noColor] [--noEmoji] [-h] [--profileId <value>] [--providerName <value>] [-s
+    <value>] [-j] [-f]
 
-OPTIONS
-  -f, --failOnWarning          When true command will fail on warning
-  -h, --help                   show CLI help
-  -j, --json                   Formats result to JSON
-  -q, --quiet                  When set to true, disables the shell echo output of action.
-
-  -s, --scan=scan              When number provided, scan for super.json outside cwd within range represented by this
-                               number.
-
-  --noColor                    When set to true, disables all colored output.
-
-  --noEmoji                    When set to true, disables displaying emoji in output.
-
-  --profileId=profileId        Profile Id in format [scope/](optional)[name]
-
-  --providerName=providerName  Name of provider.
+FLAGS
+  -f, --failOnWarning     When true command will fail on warning
+  -h, --help              show CLI help
+  -j, --json              Formats result to JSON
+  -q, --quiet             When set to true, disables the shell echo output of action.
+  -s, --scan=<value>      When number provided, scan for super.json outside cwd within range represented by this number.
+  --noColor               When set to true, disables all colored output.
+  --noEmoji               When set to true, disables displaying emoji in output.
+  --profileId=<value>     Profile Id in format [scope/](optional)[name]
+  --providerName=<value>  Name of provider.
 
 DESCRIPTION
+  Checks all maps, profiles and providers locally linked in super.json. Also can be used to check specific profile and
+  its maps, in that case remote files can be used.
   Command ends with non zero exit code if errors are found.
 
 EXAMPLES
   $ superface check
+
   $ superface check -f
+
   $ superface check --profileId starwars/character-information
+
   $ superface check --profileId starwars/character-information --providerName swapi
+
   $ superface check --profileId starwars/character-information --providerName swapi -j
+
   $ superface check --profileId starwars/character-information --providerName swapi -s 3
+
   $ superface check --profileId starwars/character-information --providerName swapi -q
 ```
 
@@ -116,32 +120,35 @@ Compiles locally linked maps and profiles in `super.json`. When running without 
 
 ```
 USAGE
-  $ superface compile
+  $ superface compile [-q] [--noColor] [--noEmoji] [-h] [--profileId <value>] [--providerName <value>] [-s
+    <value>] [--onlyProfile | --onlyMap]
 
-OPTIONS
-  -h, --help                   show CLI help
-  -q, --quiet                  When set to true, disables the shell echo output of action.
+FLAGS
+  -h, --help              show CLI help
+  -q, --quiet             When set to true, disables the shell echo output of action.
+  -s, --scan=<value>      When number provided, scan for super.json outside cwd within range represented by this number.
+  --noColor               When set to true, disables all colored output.
+  --noEmoji               When set to true, disables displaying emoji in output.
+  --onlyMap               Compile only a map/maps
+  --onlyProfile           Compile only a profile/profiles
+  --profileId=<value>     Profile Id in format [scope/](optional)[name]
+  --providerName=<value>  Name of provider. This argument is used to compile map
 
-  -s, --scan=scan              When number provided, scan for super.json outside cwd within range represented by this
-                               number.
-
-  --noColor                    When set to true, disables all colored output.
-
-  --noEmoji                    When set to true, disables displaying emoji in output.
-
-  --onlyMap                    Compile only a map/maps
-
-  --onlyProfile                Compile only a profile/profiles
-
-  --profileId=profileId        Profile Id in format [scope/](optional)[name]
-
-  --providerName=providerName  Name of provider. This argument is used to compile map
+DESCRIPTION
+  Compiles locally linked maps and profiles in `super.json`. When running without `--profileId` flag, all locally linked
+  files are compiled. When running with `--profileId`, a single local profile source file, and all its local maps are
+  compiled. When running with `--profileId` and `--providerName`, a single local profile and a single local map are
+  compiled.
 
 EXAMPLES
   $ superface compile
+
   $ superface compile --profileId starwars/character-information --profile
+
   $ superface compile --profileId starwars/character-information --profile -q
+
   $ superface compile --profileId starwars/character-information --providerName swapi --onlyMap
+
   $ superface compile --profileId starwars/character-information --providerName swapi --onlyProfile
 ```
 
@@ -153,29 +160,39 @@ Configures new provider and map for already installed profile. Provider configur
 
 ```
 USAGE
-  $ superface configure PROVIDERNAME
+  $ superface configure [PROVIDERNAME] -p <value> [-q] [--noColor] [--noEmoji] [-h] [--write-env] [-f]
+    [--localProvider <value>] [--localMap <value>] [--mapVariant <value>]
 
 ARGUMENTS
   PROVIDERNAME  Provider name.
 
-OPTIONS
-  -f, --force                    When set to true and when provider exists in super.json, overwrites them.
-  -h, --help                     show CLI help
-  -p, --profile=profile          (required) Specifies profile to associate with provider
-  -q, --quiet                    When set to true, disables the shell echo output of action.
-  --localMap=localMap            Optional filepath to .suma map file
-  --localProvider=localProvider  Optional filepath to provider.json file
-  --mapVariant=mapVariant        Optional map variant
-  --noColor                      When set to true, disables all colored output.
-  --noEmoji                      When set to true, disables displaying emoji in output.
-  --write-env                    When set to true command writes security variables to .env file
+FLAGS
+  -f, --force              When set to true and when provider exists in super.json, overwrites them.
+  -h, --help               show CLI help
+  -p, --profile=<value>    (required) Specifies profile to associate with provider
+  -q, --quiet              When set to true, disables the shell echo output of action.
+  --localMap=<value>       Optional filepath to .suma map file
+  --localProvider=<value>  Optional filepath to provider.json file
+  --mapVariant=<value>     Optional map variant
+  --noColor                When set to true, disables all colored output.
+  --noEmoji                When set to true, disables displaying emoji in output.
+  --write-env              When set to true command writes security variables to .env file
+
+DESCRIPTION
+  Configures new provider and map for already installed profile. Provider configuration is dowloaded from a Superface
+  registry or from local file.
 
 EXAMPLES
   $ superface configure twilio -p send-sms
+
   $ superface configure twilio -p send-sms -q
+
   $ superface configure twilio -p send-sms -f
+
   $ superface configure twilio -p send-sms --localProvider providers/twilio.provider.json
+
   $ superface configure twilio -p send-sms --localMap maps/send-sms.twilio.suma
+
   $ superface configure twilio -p send-sms --mapVariant generated
 ```
 
@@ -187,58 +204,52 @@ Creates empty map, profile or/and provider on a local filesystem.
 
 ```
 USAGE
-  $ superface create
+  $ superface create [--noColor] [--noEmoji] [-h] [--profileId <value>] [--providerName <value>] [-u
+    <value>] [-t <value>] [-v <value>] [--init | --no-init] [--no-super-json] [-i | -q | --profile | --map | --provider]
+    [-p <value>] [--mapFileName <value>] [--profileFileName <value>] [--providerFileName <value>] [-s <value>]
 
-OPTIONS
-  -h, --help                           show CLI help
-  -i, --interactive                    When set to true, command is used in interactive mode.
-  -p, --path=path                      Base path where files will be created
-  -q, --quiet                          When set to true, disables the shell echo output of action.
+FLAGS
+  -h, --help                  show CLI help
+  -i, --interactive           When set to true, command is used in interactive mode.
+  -p, --path=<value>          Base path where files will be created
+  -q, --quiet                 When set to true, disables the shell echo output of action.
+  -s, --scan=<value>          When number provided, scan for super.json outside cwd within range represented by this
+                              number.
+  -t, --variant=<value>       Variant of a map
+  -u, --usecase=<value>...    Usecases that profile or map contains
+  -v, --version=<value>       [default: 1.0.0] Version of a profile
+  --init                      When set to true, command will initialize Superface
+  --map                       Create a map
+  --mapFileName=<value>       Name of map file
+  --no-init                   When set to true, command won't initialize Superface
+  --no-super-json             When set to true, command won't change SuperJson file
+  --noColor                   When set to true, disables all colored output.
+  --noEmoji                   When set to true, disables displaying emoji in output.
+  --profile                   Create a profile
+  --profileFileName=<value>   Name of profile file
+  --profileId=<value>         Profile Id in format [scope](optional)/[name]
+  --provider                  Create a provider
+  --providerFileName=<value>  Name of provider file
+  --providerName=<value>...   Names of providers. This argument is used to create maps and/or providers
 
-  -s, --scan=scan                      When number provided, scan for super.json outside cwd within range represented by
-                                       this number.
-
-  -t, --variant=variant                Variant of a map
-
-  -u, --usecase=usecase                Usecases that profile or map contains
-
-  -v, --version=version                [default: 1.0.0] Version of a profile
-
-  --init                               When set to true, command will initialize Superface
-
-  --map                                Create a map
-
-  --mapFileName=mapFileName            Name of map file
-
-  --no-init                            When set to true, command won't initialize Superface
-
-  --no-super-json                      When set to true, command won't change SuperJson file
-
-  --noColor                            When set to true, disables all colored output.
-
-  --noEmoji                            When set to true, disables displaying emoji in output.
-
-  --profile                            Create a profile
-
-  --profileFileName=profileFileName    Name of profile file
-
-  --profileId=profileId                Profile Id in format [scope](optional)/[name]
-
-  --provider                           Create a provider
-
-  --providerFileName=providerFileName  Name of provider file
-
-  --providerName=providerName          Names of providers. This argument is used to create maps and/or providers
+DESCRIPTION
+  Creates empty map, profile or/and provider on a local filesystem.
 
 EXAMPLES
   $ superface create --profileId sms/service --profile
+
   $ superface create --profileId sms/service --profile -v 1.1-rev133 -u SendSMS ReceiveSMS
+
   $ superface create --profileId sms/service --providerName twilio --map
+
   $ superface create --profileId sms/service --providerName twilio --map -t bugfix
+
   $ superface create --providerName twilio tyntec --provider
+
   $ superface create --providerName twilio --provider --providerFileName my-provider -p my/path
-  $ superface create --profileId sms/service --providerName twilio --provider --map --profile -t bugfix -v 1.1-rev133 -u
-   SendSMS ReceiveSMS
+
+  $ superface create --profileId sms/service --providerName twilio --provider --map --profile -t bugfix -v 1.1-rev133 -u SendSMS ReceiveSMS
+
   $ superface create -i
 ```
 
@@ -253,25 +264,31 @@ Initializes superface local folder structure.
 
 ```
 USAGE
-  $ superface init [NAME]
+  $ superface init [NAME] [-q] [--noColor] [--noEmoji] [-h] [--profiles <value>] [--providers <value>] [-p]
 
 ARGUMENTS
   NAME  Name of parent directory.
 
-OPTIONS
-  -h, --help             show CLI help
-  -p, --prompt           When set to true, prompt will be executed.
-  -q, --quiet            When set to true, disables the shell echo output of action.
-  --noColor              When set to true, disables all colored output.
-  --noEmoji              When set to true, disables displaying emoji in output.
-  --profiles=profiles    Profile identifiers.
-  --providers=providers  Provider names.
+FLAGS
+  -h, --help              show CLI help
+  -p, --prompt            When set to true, prompt will be executed.
+  -q, --quiet             When set to true, disables the shell echo output of action.
+  --noColor               When set to true, disables all colored output.
+  --noEmoji               When set to true, disables displaying emoji in output.
+  --profiles=<value>...   Profile identifiers.
+  --providers=<value>...  Provider names.
+
+DESCRIPTION
+  Initializes superface local folder structure.
 
 EXAMPLES
-  superface init
-  superface init foo
-  superface init foo --providers bar twilio
-  superface init foo --profiles my-profile@1.1.0 another-profile@2.0 --providers osm gmaps
+  $ superface init
+
+  $ superface init foo
+
+  $ superface init foo --providers bar twilio
+
+  $ superface init foo --profiles my-profile@1.1.0 another-profile@2.0 --providers osm gmaps
 ```
 
 _See code: [src/commands/init.ts](https://github.com/superfaceai/cli/tree/main/src/commands/init.ts)_
@@ -282,30 +299,36 @@ Automatically initializes superface directory in current working directory if ne
 
 ```
 USAGE
-  $ superface install [PROFILEID]
+  $ superface install [PROFILEID] [-q] [--noColor] [--noEmoji] [-h] [-p <value>] [-f] [-l] [-s <value>]
 
 ARGUMENTS
   PROFILEID  Profile identifier consisting of scope (optional), profile name and its version.
 
-OPTIONS
-  -f, --force                When set to true and when profile exists in local filesystem, overwrites them.
-  -h, --help                 show CLI help
-  -l, --local                When set to true, profile id argument is used as a filepath to profile.supr file.
-  -p, --providers=providers  Provider name.
-  -q, --quiet                When set to true, disables the shell echo output of action.
+FLAGS
+  -f, --force                 When set to true and when profile exists in local filesystem, overwrites them.
+  -h, --help                  show CLI help
+  -l, --local                 When set to true, profile id argument is used as a filepath to profile.supr file.
+  -p, --providers=<value>...  Provider name.
+  -q, --quiet                 When set to true, disables the shell echo output of action.
+  -s, --scan=<value>          When number provided, scan for super.json outside cwd within range represented by this
+                              number.
+  --noColor                   When set to true, disables all colored output.
+  --noEmoji                   When set to true, disables displaying emoji in output.
 
-  -s, --scan=scan            When number provided, scan for super.json outside cwd within range represented by this
-                             number.
-
-  --noColor                  When set to true, disables all colored output.
-
-  --noEmoji                  When set to true, disables displaying emoji in output.
+DESCRIPTION
+  Automatically initializes superface directory in current working directory if needed, communicates with Superface
+  Store API, stores profiles and compiled files to a local system. Install without any arguments tries to install
+  profiles and providers listed in super.json
 
 EXAMPLES
   $ superface install
+
   $ superface install sms/service@1.0
+
   $ superface install sms/service@1.0 --providers twilio tyntec
+
   $ superface install sms/service@1.0 -p twilio
+
   $ superface install --local sms/service.supr
 ```
 
@@ -317,41 +340,42 @@ Lints all maps and profiles locally linked in super.json. Also can be used to li
 
 ```
 USAGE
-  $ superface lint
+  $ superface lint [-q] [--noColor] [--noEmoji] [-h] [--providerName <value>] [--profileId <value>] [-o
+    <value>] [--append] [-f long|short|json] [-s <value>]
 
-OPTIONS
-  -f, --outputFormat=long|short|json  [default: short] Output format to use to display errors and warnings.
-  -h, --help                          show CLI help
-
-  -o, --output=output                 [default: -] Filename where the output will be written. `-` is stdout, `-2` is
-                                      stderr.
-
-  -q, --quiet                         When set to true, disables the shell echo output of action.
-
-  -s, --scan=scan                     When number provided, scan for super.json outside cwd within range represented by
-                                      this number.
-
-  --append                            Open output file in append mode instead of truncating it if it exists. Has no
-                                      effect with stdout and stderr streams.
-
-  --noColor                           When set to true, disables all colored output.
-
-  --noEmoji                           When set to true, disables displaying emoji in output.
-
-  --profileId=profileId               Profile Id in format [scope/](optional)[name]
-
-  --providerName=providerName         Provider name
+FLAGS
+  -f, --outputFormat=<option>  [default: short] Output format to use to display errors and warnings.
+                               <options: long|short|json>
+  -h, --help                   show CLI help
+  -o, --output=<value>         [default: -] Filename where the output will be written. `-` is stdout, `-2` is stderr.
+  -q, --quiet                  When set to true, disables the shell echo output of action.
+  -s, --scan=<value>           When number provided, scan for super.json outside cwd within range represented by this
+                               number.
+  --append                     Open output file in append mode instead of truncating it if it exists. Has no effect with
+                               stdout and stderr streams.
+  --noColor                    When set to true, disables all colored output.
+  --noEmoji                    When set to true, disables displaying emoji in output.
+  --profileId=<value>          Profile Id in format [scope/](optional)[name]
+  --providerName=<value>       Provider name
 
 DESCRIPTION
+  Lints all maps and profiles locally linked in super.json. Also can be used to lint specific profile and its maps, in
+  that case remote files can be used.Outputs the linter issues to STDOUT by default.
   Linter ends with non zero exit code if errors are found.
 
 EXAMPLES
   $ superface lint
+
   $ superface lint -f long
+
   $ superface lint --profileId starwars/character-information
+
   $ superface lint --profileId starwars/character-information --providerName swapi
+
   $ superface lint -o -2
+
   $ superface lint -f json
+
   $ superface lint -s 3
 ```
 
@@ -363,17 +387,21 @@ Login to superface server
 
 ```
 USAGE
-  $ superface login
+  $ superface login [-q] [--noColor] [--noEmoji] [-h] [-f]
 
-OPTIONS
+FLAGS
   -f, --force  When set to true user won't be asked to confirm browser opening
   -h, --help   show CLI help
   -q, --quiet  When set to true, disables the shell echo output of action.
   --noColor    When set to true, disables all colored output.
   --noEmoji    When set to true, disables displaying emoji in output.
 
+DESCRIPTION
+  Login to superface server
+
 EXAMPLES
   $ superface login
+
   $ superface login -f
 ```
 
@@ -385,15 +413,18 @@ Logs out logged in user
 
 ```
 USAGE
-  $ superface logout
+  $ superface logout [-q] [--noColor] [--noEmoji] [-h]
 
-OPTIONS
+FLAGS
   -h, --help   show CLI help
   -q, --quiet  When set to true, disables the shell echo output of action.
   --noColor    When set to true, disables all colored output.
   --noEmoji    When set to true, disables displaying emoji in output.
 
-EXAMPLE
+DESCRIPTION
+  Logs out logged in user
+
+EXAMPLES
   $ superface logout
 ```
 
@@ -405,24 +436,32 @@ Prepares map, based on profile and provider on a local filesystem. Created file 
 
 ```
 USAGE
-  $ superface prepare:map PROFILEID PROVIDERNAME
+  $ superface prepare:map [PROFILEID] [PROVIDERNAME] [-q] [--noColor] [--noEmoji] [-h] [-s <value>] [-f]
+    [--station]
 
 ARGUMENTS
   PROFILEID     Profile Id in format [scope](optional)/[name]
   PROVIDERNAME  Name of provider
 
-OPTIONS
-  -f, --force      When set to true and when profile exists in local filesystem, overwrites them.
-  -h, --help       show CLI help
-  -q, --quiet      When set to true, disables the shell echo output of action.
-  -s, --scan=scan  When number provided, scan for super.json outside cwd within range represented by this number.
-  --noColor        When set to true, disables all colored output.
-  --noEmoji        When set to true, disables displaying emoji in output.
-  --station        When set to true, command will create map in folder structure of Superface station
+FLAGS
+  -f, --force         When set to true and when profile exists in local filesystem, overwrites them.
+  -h, --help          show CLI help
+  -q, --quiet         When set to true, disables the shell echo output of action.
+  -s, --scan=<value>  When number provided, scan for super.json outside cwd within range represented by this number.
+  --noColor           When set to true, disables all colored output.
+  --noEmoji           When set to true, disables displaying emoji in output.
+  --station           When set to true, command will create map in folder structure of Superface station
+
+DESCRIPTION
+  Prepares map, based on profile and provider on a local filesystem. Created file contains prepared structure with
+  information from profile and provider files. Before running this command you should have prepared profile (run sf
+  prepare:profile) and provider (run sf prepare:provider)
 
 EXAMPLES
   $ superface prepare:map starwars/character-information swapi --force
+
   $ superface prepare:map starwars/character-information swapi -s 3
+
   $ superface prepare:map starwars/character-information swapi --station
 ```
 
@@ -434,27 +473,67 @@ Prepares map for mock provider on a local filesystem. Created map always returns
 
 ```
 USAGE
-  $ superface prepare:mock-map PROFILEID
+  $ superface prepare:mock-map [PROFILEID] [-q] [--noColor] [--noEmoji] [-h] [-s <value>] [-f] [--station]
 
 ARGUMENTS
   PROFILEID  Profile Id in format [scope](optional)/[name]
 
-OPTIONS
-  -f, --force      When set to true and when profile exists in local filesystem, overwrites them.
-  -h, --help       show CLI help
-  -q, --quiet      When set to true, disables the shell echo output of action.
-  -s, --scan=scan  When number provided, scan for super.json outside cwd within range represented by this number.
-  --noColor        When set to true, disables all colored output.
-  --noEmoji        When set to true, disables displaying emoji in output.
-  --station        When set to true, command will create map in folder structure of Superface station
+FLAGS
+  -f, --force         When set to true and when profile exists in local filesystem, overwrites them.
+  -h, --help          show CLI help
+  -q, --quiet         When set to true, disables the shell echo output of action.
+  -s, --scan=<value>  When number provided, scan for super.json outside cwd within range represented by this number.
+  --noColor           When set to true, disables all colored output.
+  --noEmoji           When set to true, disables displaying emoji in output.
+  --station           When set to true, command will create map in folder structure of Superface station
+
+DESCRIPTION
+  Prepares map for mock provider on a local filesystem. Created map always returns success result example from profile
+  file. Before running this command you should have prepared profile file (run sf prepare:profile).
 
 EXAMPLES
   $ superface prepare:mock-map starwars/character-information --force
+
   $ superface prepare:mock-map starwars/character-information -s 3
+
   $ superface prepare:mock-map starwars/character-information --station
 ```
 
 _See code: [dist/commands/prepare/mock-map.ts](https://github.com/superfaceai/cli/tree/main/src/commands/prepare/mock-map.ts)_
+
+## `superface prepare:mock-map-test PROFILEID`
+
+Prepares test for mock provider map on a local filesystem. Created test expects success result example from profile file. Before running this command you should have prepared mock provider map (run sf prepare:mock-map).
+
+```
+USAGE
+  $ superface prepare:mock-map-test [PROFILEID] [-q] [--noColor] [--noEmoji] [-h] [-s <value>] [-f] [--station]
+
+ARGUMENTS
+  PROFILEID  Profile Id in format [scope](optional)/[name]
+
+FLAGS
+  -f, --force         When set to true and when profile exists in local filesystem, overwrites them.
+  -h, --help          show CLI help
+  -q, --quiet         When set to true, disables the shell echo output of action.
+  -s, --scan=<value>  When number provided, scan for super.json outside cwd within range represented by this number.
+  --noColor           When set to true, disables all colored output.
+  --noEmoji           When set to true, disables displaying emoji in output.
+  --station           When set to true, command will create map in folder structure of Superface station
+
+DESCRIPTION
+  Prepares test for mock provider map on a local filesystem. Created test expects success result example from profile
+  file. Before running this command you should have prepared mock provider map (run sf prepare:mock-map).
+
+EXAMPLES
+  $ superface prepare:mock-map-test starwars/character-information --force
+
+  $ superface prepare:mock-map-test starwars/character-information -s 3
+
+  $ superface prepare:mock-map-test starwars/character-information --station
+```
+
+_See code: [dist/commands/prepare/mock-map-test.ts](https://github.com/superfaceai/cli/tree/main/src/commands/prepare/mock-map-test.ts)_
 
 ## `superface prepare:test PROFILEID PROVIDERNAME`
 
@@ -462,25 +541,33 @@ Prepares test file for specified profile and provider. Examples in profile are u
 
 ```
 USAGE
-  $ superface prepare:test PROFILEID PROVIDERNAME
+  $ superface prepare:test [PROFILEID] [PROVIDERNAME] [-q] [--noColor] [--noEmoji] [-h] [-s <value>] [-f]
+    [--station]
 
 ARGUMENTS
   PROFILEID     Profile Id in format [scope](optional)/[name]
   PROVIDERNAME  Name of provider
 
-OPTIONS
-  -f, --force      When set to true and when profile exists in local filesystem, overwrites them.
-  -h, --help       show CLI help
-  -q, --quiet      When set to true, disables the shell echo output of action.
-  -s, --scan=scan  When number provided, scan for super.json outside cwd within range represented by this number.
-  --noColor        When set to true, disables all colored output.
-  --noEmoji        When set to true, disables displaying emoji in output.
-  --station        When set to true, command will create map in folder structure of Superface station
+FLAGS
+  -f, --force         When set to true and when profile exists in local filesystem, overwrites them.
+  -h, --help          show CLI help
+  -q, --quiet         When set to true, disables the shell echo output of action.
+  -s, --scan=<value>  When number provided, scan for super.json outside cwd within range represented by this number.
+  --noColor           When set to true, disables all colored output.
+  --noEmoji           When set to true, disables displaying emoji in output.
+  --station           When set to true, command will create map in folder structure of Superface station
+
+DESCRIPTION
+  Prepares test file for specified profile and provider. Examples in profile are used as an input and
+  @superfaceai/testing library is used to orchestrate tests.
 
 EXAMPLES
   $ superface prepare:test starwars/character-information swapi
+
   $ superface prepare:test starwars/character-information swapi --station
+
   $ superface prepare:test starwars/character-information swapi --force
+
   $ superface prepare:test starwars/character-information swapi -q
 ```
 
@@ -492,34 +579,36 @@ Uploads map/profile/provider to Store. Published file must be locally linked in 
 
 ```
 USAGE
-  $ superface publish DOCUMENTTYPE
+  $ superface publish [DOCUMENTTYPE] --profileId <value> --providerName <value> [-q] [--noColor] [--noEmoji]
+    [-h] [--dryRun] [-f] [-s <value>] [-j]
 
 ARGUMENTS
   DOCUMENTTYPE  (map|profile|provider) Document type of published file
 
-OPTIONS
-  -f, --force                  Publishes without asking for any confirmation.
-  -h, --help                   show CLI help
-  -j, --json                   Formats result to JSON
-  -q, --quiet                  When set to true, disables the shell echo output of action.
+FLAGS
+  -f, --force             Publishes without asking for any confirmation.
+  -h, --help              show CLI help
+  -j, --json              Formats result to JSON
+  -q, --quiet             When set to true, disables the shell echo output of action.
+  -s, --scan=<value>      When a number is provided, scan for super.json outside cwd within the range represented by
+                          this number.
+  --dryRun                Runs without sending the actual request.
+  --noColor               When set to true, disables all colored output.
+  --noEmoji               When set to true, disables displaying emoji in output.
+  --profileId=<value>     (required) Profile Id in format [scope/](optional)[name]
+  --providerName=<value>  (required) Name of the provider. This argument is used to publish a map or a provider.
 
-  -s, --scan=scan              When a number is provided, scan for super.json outside cwd within the range represented
-                               by this number.
-
-  --dryRun                     Runs without sending the actual request.
-
-  --noColor                    When set to true, disables all colored output.
-
-  --noEmoji                    When set to true, disables displaying emoji in output.
-
-  --profileId=profileId        (required) Profile Id in format [scope/](optional)[name]
-
-  --providerName=providerName  (required) Name of the provider. This argument is used to publish a map or a provider.
+DESCRIPTION
+  Uploads map/profile/provider to Store. Published file must be locally linked in super.json. This command runs Check
+  and Lint internaly to ensure quality
 
 EXAMPLES
   $ superface publish map --profileId starwars/character-information --providerName swapi -s 4
+
   $ superface publish profile --profileId starwars/character-information --providerName swapi -f
+
   $ superface publish provider --profileId starwars/character-information --providerName swapi -q
+
   $ superface publish profile --profileId starwars/character-information --providerName swapi --dryRun
 ```
 
@@ -531,16 +620,20 @@ Prints info about logged in user
 
 ```
 USAGE
-  $ superface whoami
+  $ superface whoami [-q] [--noColor] [--noEmoji] [-h]
 
-OPTIONS
+FLAGS
   -h, --help   show CLI help
   -q, --quiet  When set to true, disables the shell echo output of action.
   --noColor    When set to true, disables all colored output.
   --noEmoji    When set to true, disables displaying emoji in output.
 
+DESCRIPTION
+  Prints info about logged in user
+
 EXAMPLES
   $ superface whoami
+
   $ sf whoami
 ```
 

--- a/src/commands/prepare/mock-map-test.test.ts
+++ b/src/commands/prepare/mock-map-test.test.ts
@@ -1,0 +1,201 @@
+import {
+  err,
+  loadSuperJson,
+  ok,
+  SDKExecutionError,
+} from '@superfaceai/one-sdk';
+
+import { MockLogger } from '../../common';
+import { createUserError } from '../../common/error';
+import { ProfileId } from '../../common/profile';
+import { detectSuperJson } from '../../logic/install';
+import { prepareMockMapTest } from '../../logic/prepare/mock-map-test';
+import { CommandInstance } from '../../test/utils';
+import { MockMapTest } from './mock-map-test';
+
+jest.mock('../../logic/install', () => ({
+  detectSuperJson: jest.fn(),
+}));
+
+jest.mock('../../logic/prepare/mock-map-test', () => ({
+  prepareMockMapTest: jest.fn(),
+}));
+
+jest.mock('@superfaceai/one-sdk', () => ({
+  ...jest.requireActual('@superfaceai/one-sdk'),
+  loadSuperJson: jest.fn(),
+}));
+
+describe('Prepare mock map test command', () => {
+  const userError = createUserError(false);
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('running prepare command', () => {
+    let instance: MockMapTest;
+    let logger: MockLogger;
+
+    const mockProfile = 'starwars/character-information';
+
+    beforeEach(() => {
+      instance = CommandInstance(MockMapTest);
+      logger = new MockLogger();
+    });
+
+    it('throws when super.json not found', async () => {
+      jest.mocked(detectSuperJson).mockResolvedValue(undefined);
+      await expect(
+        instance.execute({
+          logger,
+          userError,
+          flags: {},
+          args: { profileId: mockProfile },
+        })
+      ).rejects.toThrow('Unable to load super.json, super.json not found');
+    });
+
+    it('throws when super.json not loaded correctly', async () => {
+      jest.mocked(detectSuperJson).mockResolvedValue('.');
+      jest
+        .mocked(loadSuperJson)
+        .mockResolvedValue(err(new SDKExecutionError('test error', [], [])));
+      await expect(
+        instance.execute({
+          logger,
+          userError,
+          flags: {},
+          args: { profileId: mockProfile },
+        })
+      ).rejects.toThrow('Unable to load super.json: test error');
+    });
+
+    it('throws error on scan flag higher than 5', async () => {
+      jest.mocked(detectSuperJson).mockResolvedValue('.');
+
+      await expect(
+        instance.execute({
+          logger,
+          userError,
+          args: { profileId: mockProfile },
+          flags: {
+            scan: 7,
+          },
+        })
+      ).rejects.toThrow(
+        '--scan/-s : Number of levels to scan cannot be higher than 5'
+      );
+      expect(detectSuperJson).not.toHaveBeenCalled();
+    }, 10000);
+
+    it('throws error on invalid profile id', async () => {
+      jest.mocked(detectSuperJson).mockResolvedValue('.');
+      jest.mocked(loadSuperJson).mockResolvedValue(ok({}));
+
+      await expect(
+        instance.execute({
+          logger,
+          userError,
+          args: { profileId: 'U!0_' },
+          flags: {
+            scan: 3,
+          },
+        })
+      ).rejects.toThrow(
+        'Invalid profile id: "U!0_" is not a valid lowercase identifier'
+      );
+      expect(detectSuperJson).not.toHaveBeenCalled();
+      expect(loadSuperJson).not.toHaveBeenCalled();
+    }, 10000);
+
+    it('throws error on profile id not found in super.json', async () => {
+      jest.mocked(detectSuperJson).mockResolvedValue('.');
+      jest.mocked(loadSuperJson).mockResolvedValue(ok({}));
+
+      await expect(
+        instance.execute({
+          logger,
+          userError,
+          args: { profileId: mockProfile },
+          flags: {
+            scan: 3,
+          },
+        })
+      ).rejects.toThrow(
+        `Unable to prepare, profile: "${mockProfile}" not found in super.json`
+      );
+    }, 10000);
+
+    it('passes empty flags to logic', async () => {
+      const superJson = {
+        profiles: {
+          [mockProfile]: {
+            file: '',
+          },
+        },
+      };
+
+      const superJsonPath = '.';
+      jest.mocked(detectSuperJson).mockResolvedValue(superJsonPath);
+      jest.mocked(loadSuperJson).mockResolvedValue(ok(superJson));
+
+      await instance.execute({
+        logger,
+        userError,
+        args: { profileId: mockProfile },
+        flags: {
+          scan: 3,
+        },
+      });
+
+      expect(prepareMockMapTest).toBeCalledWith(
+        {
+          profile: ProfileId.fromId(mockProfile, { userError }),
+          superJson,
+          superJsonPath: 'super.json',
+          options: {},
+        },
+        { logger }
+      );
+    }, 10000);
+
+    it('passes flags to logic', async () => {
+      const superJson = {
+        profiles: {
+          [mockProfile]: {
+            file: '',
+          },
+        },
+      };
+
+      const superJsonPath = '.';
+      jest.mocked(detectSuperJson).mockResolvedValue(superJsonPath);
+      jest.mocked(loadSuperJson).mockResolvedValue(ok(superJson));
+
+      await instance.execute({
+        logger,
+        userError,
+        args: { profileId: mockProfile },
+        flags: {
+          force: true,
+          station: true,
+          scan: 3,
+        },
+      });
+
+      expect(prepareMockMapTest).toBeCalledWith(
+        {
+          profile: ProfileId.fromId(mockProfile, { userError }),
+          superJson,
+          superJsonPath: 'super.json',
+          options: {
+            station: true,
+            force: true,
+          },
+        },
+        { logger }
+      );
+    }, 10000);
+  });
+});

--- a/src/commands/prepare/mock-map-test.ts
+++ b/src/commands/prepare/mock-map-test.ts
@@ -1,0 +1,126 @@
+import { flags as oclifFlags } from '@oclif/command';
+import { normalizeSuperJsonDocument } from '@superfaceai/one-sdk';
+import { parseDocumentId } from '@superfaceai/parser';
+
+import type { ILogger } from '../../common';
+import { loadSuperJson } from '../../common';
+import type { Flags } from '../../common/command.abstract';
+import { Command } from '../../common/command.abstract';
+import type { UserError } from '../../common/error';
+import { ProfileId } from '../../common/profile';
+import { prepareMockMapTest } from '../../logic/prepare/mock-map-test';
+
+export class MockMapTest extends Command {
+  public static strict = true;
+
+  public static description =
+    'Prepares test for mock provider map on a local filesystem. Created test expects success result example from profile file. Before running this command you should have prepared mock provider map (run sf prepare:mock-map).';
+
+  public static args = [
+    {
+      name: 'profileId',
+      description: 'Profile Id in format [scope](optional)/[name]',
+      required: true,
+    },
+  ];
+
+  public static flags = {
+    ...Command.flags,
+    // Inputs
+    scan: oclifFlags.integer({
+      char: 's',
+      description:
+        'When number provided, scan for super.json outside cwd within range represented by this number.',
+      required: false,
+    }),
+    force: oclifFlags.boolean({
+      char: 'f',
+      description:
+        'When set to true and when profile exists in local filesystem, overwrites them.',
+      default: false,
+    }),
+    station: oclifFlags.boolean({
+      default: false,
+      description:
+        'When set to true, command will create map in folder structure of Superface station',
+    }),
+  };
+
+  public static examples = [
+    '$ superface prepare:mock-map-test starwars/character-information --force',
+    '$ superface prepare:mock-map-test starwars/character-information -s 3',
+    '$ superface prepare:mock-map-test starwars/character-information --station',
+  ];
+
+  public async run(): Promise<void> {
+    const { args, flags } = this.parse(MockMapTest);
+    await super.initialize(flags);
+    await this.execute({
+      logger: this.logger,
+      userError: this.userError,
+      flags,
+      args,
+    });
+  }
+
+  public async execute({
+    logger,
+    userError,
+    flags,
+    args,
+  }: {
+    logger: ILogger;
+    userError: UserError;
+    flags: Flags<typeof MockMapTest.flags>;
+    args: { profileId?: string };
+  }): Promise<void> {
+    // Check inputs
+    if (args.profileId === undefined) {
+      throw userError(`Missing profile id`, 1);
+    }
+
+    const parsedProfileId = parseDocumentId(args.profileId);
+    if (parsedProfileId.kind == 'error') {
+      throw userError(`Invalid profile id: ${parsedProfileId.message}`, 1);
+    }
+
+    if (
+      flags.scan !== undefined &&
+      (typeof flags.scan !== 'number' || flags.scan > 5)
+    ) {
+      throw userError(
+        '--scan/-s : Number of levels to scan cannot be higher than 5',
+        1
+      );
+    }
+    const { superJson, superJsonPath } = await loadSuperJson({
+      scan: flags.scan,
+      userError,
+    });
+
+    const normalized = normalizeSuperJsonDocument(superJson);
+
+    // Check super.json
+    if (normalized.profiles[args.profileId] === undefined) {
+      throw userError(
+        `Unable to prepare, profile: "${args.profileId}" not found in super.json`,
+        1
+      );
+    }
+
+    await prepareMockMapTest(
+      {
+        profile: ProfileId.fromId(args.profileId, { userError }),
+        superJson,
+        superJsonPath,
+        options: {
+          force: flags.force,
+          station: flags.station,
+        },
+      },
+      {
+        logger,
+      }
+    );
+  }
+}

--- a/src/common/messages.ts
+++ b/src/common/messages.ts
@@ -147,14 +147,12 @@ const configure = {
     superJsonPath: string,
     description?: string
   ) =>
-    `Parameter: "${name}"${
-      description !== undefined ? ` with description: "${description}"` : ''
+    `Parameter: "${name}"${description !== undefined ? ` with description: "${description}"` : ''
     } has not been configured\nPlease, configure this parameter manually in "super.json" in: "${superJsonPath}"`,
   parameterConfigured: (name: string, value: string, description?: string) =>
-    `Parameter: "${name}"${
-      description !== undefined && description !== ''
-        ? ` with description: "${description}"`
-        : ''
+    `Parameter: "${name}"${description !== undefined && description !== ''
+      ? ` with description: "${description}"`
+      : ''
     } has been configured to use value of environment value "${value}".\nPlease configure this environment value`,
   parameterHasDefault: (defaultValue: string) =>
     `If you do not set the variable, the default value: "${defaultValue}" will be used`,
@@ -244,6 +242,8 @@ const create = {
     `Created profile: "${profile}" at path: "${path}"`,
   createMap: (profile: string, provider: string, path: string) =>
     `Created map for profile: "${profile}" and provider: "${provider}" at path: "${path}"`,
+  createTest: (profile: string, provider: string, path: string) =>
+    `Created map test for profile: "${profile}" and provider: "${provider}" at path: "${path}"`,
   createProvider: (provider: string, path: string) =>
     `Created provider: "${provider}" at path: "${path}"`,
   unverifiedPrefix: (provider: string, prefix: string) =>

--- a/src/logic/prepare/mock-map-test.test.ts
+++ b/src/logic/prepare/mock-map-test.test.ts
@@ -1,0 +1,120 @@
+import { MockLogger } from '../../common';
+import { OutputStream } from '../../common/output-stream';
+import { ProfileId } from '../../common/profile';
+import { mockProfileDocumentNode } from '../../test/profile-document-node';
+import { loadProfile } from '../publish.utils';
+import { prepareMockMapTest } from './mock-map-test';
+
+jest.mock('../publish.utils', () => ({
+  loadProfile: jest.fn(),
+}));
+
+describe('Prepare mock map test logic', () => {
+  let logger: MockLogger;
+  const profileId = ProfileId.fromScopeName('test', 'profile');
+  const profilePath = 'profilePath';
+
+  const mockProfile = mockProfileDocumentNode({
+    name: profileId.name,
+    scope: profileId.scope,
+  });
+  const mockSuperJson = {
+    profiles: {
+      [profileId.id]: {
+        file: profilePath,
+      },
+    },
+  };
+
+  const superJsonPath = 'path/to/super.json';
+
+  const writeOnceSpy = jest.spyOn(OutputStream, 'writeOnce');
+
+  beforeEach(() => {
+    writeOnceSpy.mockResolvedValue(undefined);
+
+    logger = new MockLogger();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('Writes prepared test to file', async () => {
+    jest.mocked(loadProfile).mockResolvedValue({
+      ast: mockProfile,
+      from: { kind: 'local', path: '', source: '' },
+    });
+
+    await prepareMockMapTest(
+      {
+        profile: profileId,
+        superJson: mockSuperJson,
+        superJsonPath,
+      },
+      {
+        logger,
+      }
+    );
+
+    expect(writeOnceSpy).toBeCalledWith(
+      `${profileId.toString()}.mock.test.ts`,
+      expect.any(String),
+      { dirs: true, force: undefined }
+    );
+  });
+
+  it('Writes prepared test to file with force flag', async () => {
+    jest.mocked(loadProfile).mockResolvedValue({
+      ast: mockProfile,
+      from: { kind: 'local', path: '', source: '' },
+    });
+
+    await prepareMockMapTest(
+      {
+        profile: profileId,
+        superJson: mockSuperJson,
+        superJsonPath,
+        options: {
+          force: true,
+        },
+      },
+      {
+        logger,
+      }
+    );
+
+    expect(writeOnceSpy).toBeCalledWith(
+      `${profileId.toString()}.mock.test.ts`,
+      expect.any(String),
+      { dirs: true, force: true }
+    );
+  });
+
+  it('Writes prepared test to file with station flag', async () => {
+    jest.mocked(loadProfile).mockResolvedValue({
+      ast: mockProfile,
+      from: { kind: 'local', path: '', source: '' },
+    });
+
+    await prepareMockMapTest(
+      {
+        profile: profileId,
+        superJson: mockSuperJson,
+        superJsonPath,
+        options: {
+          station: true,
+        },
+      },
+      {
+        logger,
+      }
+    );
+
+    expect(writeOnceSpy).toBeCalledWith(
+      `grid/${profileId.toString()}/maps/mock.test.ts`,
+      expect.any(String),
+      { dirs: true, force: undefined }
+    );
+  });
+});

--- a/src/logic/prepare/mock-map-test.ts
+++ b/src/logic/prepare/mock-map-test.ts
@@ -54,4 +54,5 @@ export async function prepareMockMapTest(
     dirs: true,
     force: options?.force,
   });
+  logger.success('createTest', profile.id, 'mock', filePath);
 }

--- a/src/logic/prepare/mock-map-test.ts
+++ b/src/logic/prepare/mock-map-test.ts
@@ -1,0 +1,57 @@
+import type { SuperJsonDocument } from '@superfaceai/ast';
+
+import type { ILogger } from '../../common';
+import { OutputStream } from '../../common/output-stream';
+import type { ProfileId } from '../../common/profile';
+import { prepareTestTemplate } from '../../templates/prepared-test/prepare-test';
+import { loadProfile } from '../publish.utils';
+
+/**
+ * Prepares test file fromn profile examples for specified profile and provider
+ * @param superJson SuperJson defining used profile and provider
+ * @param profile ProfileId of used profile
+ * @param provider provider name
+ * @param path optional path to test file
+ * @param fileName optional name of test file
+ * @param version optional version of used profile
+ */
+export async function prepareMockMapTest(
+  {
+    superJson,
+    superJsonPath,
+    profile,
+    version,
+    options,
+  }: {
+    superJson: SuperJsonDocument;
+    superJsonPath: string;
+    profile: ProfileId;
+    version?: string;
+    options?: {
+      force?: boolean;
+      station?: boolean;
+    };
+  },
+  { logger }: { logger: ILogger }
+): Promise<void> {
+  const { ast } = await loadProfile(
+    { superJson, superJsonPath, profile, version },
+    { logger }
+  );
+
+  // TODO: Only local files?
+  const testFileContent = prepareTestTemplate(ast, 'mock', true);
+
+  let filePath: string;
+
+  if (options?.station === true) {
+    filePath = `grid/${profile.id}/maps/mock.test.ts`;
+  } else {
+    filePath = `${profile.id}.mock.test.ts`;
+  }
+
+  await OutputStream.writeOnce(filePath, testFileContent, {
+    dirs: true,
+    force: options?.force,
+  });
+}

--- a/src/logic/prepare/test.ts
+++ b/src/logic/prepare/test.ts
@@ -56,4 +56,6 @@ export async function prepareTest(
     dirs: true,
     force: options?.force,
   });
+
+  logger.success('createTest', profile.id, provider, filePath);
 }

--- a/src/templates/prepared-test/prepare-test.ts
+++ b/src/templates/prepared-test/prepare-test.ts
@@ -7,12 +7,14 @@ import TEST_TEMPLATE from './test-templates';
 
 export function prepareTestTemplate(
   profile: ProfileDocumentNode,
-  provider: string
+  provider: string,
+  onlySuccess?: boolean
 ): string {
   const input = {
     profile: ProfileId.fromScopeName(profile.header.scope, profile.header.name)
       .id,
     useCases: prepareUseCaseDetails(profile),
+    onlySuccess,
     provider,
   };
 

--- a/src/templates/prepared-test/test-templates/test.ts
+++ b/src/templates/prepared-test/test-templates/test.ts
@@ -12,7 +12,7 @@ describe('{{profile}}/{{provider}}', () => {
   });
 
   {{#each useCases}}
-  {{>UseCase}}
+  {{>UseCase onlySuccess=../onlySuccess}}
   {{/each}}
   
 });`;

--- a/src/templates/prepared-test/test-templates/usecase.ts
+++ b/src/templates/prepared-test/test-templates/usecase.ts
@@ -1,4 +1,4 @@
 export default `describe('{{name}}', () => {
-  {{#if errorExample}}{{>Error errorExample name=name }}{{/if}}
+  {{#unless onlySuccess}}{{#if errorExample}}{{>Error errorExample name=name }}{{/if}}{{/unless}}
   {{#if successExample}}{{>Success successExample name=name }}{{/if}}
 });`;


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR adds command `prepare:mock-map-test` which generates test for map with mock provider. This file should match generated mock provider map (always return success example)

Half of the changes is formatting of commands in README by new version of oclif CLI.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
