### PR TITLE
Fix/undefined property type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `switch` and `noSwitch` flag to `publish` command
 
+### Fixed
+- Undefined type bug in `create:map` command
+
 ## [3.0.1] - 2023-02-09
 ### Fixed
 - Fixed create provider security schema resolution

--- a/src/templates/prepared-map/usecase/example/structure-tree/parse.test.ts
+++ b/src/templates/prepared-map/usecase/example/structure-tree/parse.test.ts
@@ -192,8 +192,8 @@ describe('Parse structure tree', () => {
   });
 
   describe('visitObjecDefinition', () => {
-    it('throws when type is not defined', () => {
-      expect(() =>
+    it('falls back to string when type is not defined', () => {
+      expect(
         visitObjecDefinition(
           {
             kind: 'ObjectDefinition',
@@ -208,7 +208,16 @@ describe('Parse structure tree', () => {
           {},
           {}
         )
-      ).toThrow(new Error('Type is undefined'));
+      ).toEqual({
+        kind: 'object',
+        properties: [
+          {
+            name: 'test',
+            kind: 'string',
+            value: '',
+          },
+        ],
+      });
     });
 
     it('returns example object for object with FieldDefinition fields', () => {

--- a/src/templates/prepared-map/usecase/example/structure-tree/parse.ts
+++ b/src/templates/prepared-map/usecase/example/structure-tree/parse.ts
@@ -194,10 +194,13 @@ export function visitObjecDefinition(
     kind: 'object',
     properties: object.fields.map(field => {
       const namedFieldNode = namedFieldDefinitionsCache[field.fieldName];
-      const type = field.type ?? namedFieldNode?.type;
-      if (type === undefined) {
-        throw new Error('Type is undefined');
-      }
+      // Fallback to string if type is not defined
+      const type = field.type ??
+        namedFieldNode?.type ?? {
+          kind: 'PrimitiveTypeName',
+          name: 'string',
+          location: field.location,
+        };
       const model = visit(
         type,
         namedModelDefinitionsCache,


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR fixes create:map command bug when using with fields without defined type.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
