### PR TITLE
fix: profile template without error

### DIFF
--- a/src/templates/prepared-map/map-templates/http.ts
+++ b/src/templates/prepared-map/map-templates/http.ts
@@ -31,10 +31,7 @@ http POST {{>Path input=inputExampleScalarName}} {
 
   {{assign 'step' (inc @root.step 1)}}// {{@root.step}}) Optionally map unsuccessful HTTP response to the use case error
   response 500 {
-    return map error {{#if error }}{{#ifeq error.modelType "Scalar"}}{{>Scalar error.model }}{{/ifeq}}{{#ifeq error.modelType "Object"}}{{>Object error use=" =" indent=4 }}{{/ifeq}}{{#ifeq error.modelType "List"}}{{>Array error use=":" indent=4 }}{{/ifeq}}{{newLine 2}}{{/if }}
-    {{#unless error }}
-    //empty error
-    {{/unless }}
+    {{#if error }}return map error {{#ifeq error.modelType "Scalar"}}{{>Scalar error.model }}{{/ifeq}}{{#ifeq error.modelType "Object"}}{{>Object error use=" =" indent=4 }}{{/ifeq}}{{#ifeq error.modelType "List"}}{{>Array error use=":" indent=4 }}{{/ifeq}}{{newLine 2}}{{/if }}{{#unless error }}//empty error - add error definition to profile{{/unless }}
   }
 }
 `;


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR fixes problem in `create:map` that leads to invalid map when profile does not define error

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
