### PR TITLE
Update @superfaceai/service-client to v5.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Updated @superfaceai/service-client to v5.2.1 with fixed getProvidersList, getProvider and getUserInfo methods
 
 ## [3.0.2] - 2023-03-14
 ### Added

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@superfaceai/ast": "^1.3.0",
     "@superfaceai/one-sdk": "^2.3.0",
     "@superfaceai/parser": "^2.1.0",
-    "@superfaceai/service-client": "^5.0.0",
+    "@superfaceai/service-client": "5.2.1",
     "chalk": "^4.1.0",
     "cross-fetch": "^3.1.4",
     "debug": "^4.3.1",

--- a/src/commands/whoami.integration.test.ts
+++ b/src/commands/whoami.integration.test.ts
@@ -38,7 +38,7 @@ describe('Whoami CLI command', () => {
 
       await mockServer
         .forGet('/id/user')
-        .withHeaders({ 'Content-Type': ContentType.JSON })
+        .withHeaders({ 'Accept': ContentType.JSON })
         .thenJson(200, mockUserInfo);
       const result = await execCLI(tempDir, ['whoami'], mockServer.url);
 
@@ -57,7 +57,7 @@ describe('Whoami CLI command', () => {
 
       await mockServer
         .forGet('/id/user')
-        .withHeaders({ 'Content-Type': ContentType.JSON })
+        .withHeaders({ 'Accept': ContentType.JSON })
         .thenJson(401, mockServerResponse);
       const result = await execCLI(tempDir, ['whoami'], mockServer.url);
 

--- a/src/common/http.test.ts
+++ b/src/common/http.test.ts
@@ -172,7 +172,7 @@ describe('HTTP functions', () => {
         authenticate: false,
         method: 'GET',
         headers: {
-          'Content-Type': ContentType.JSON,
+          'Accept': ContentType.JSON,
         },
       });
     }, 10000);
@@ -199,7 +199,7 @@ describe('HTTP functions', () => {
         authenticate: false,
         method: 'GET',
         headers: {
-          'Content-Type': ContentType.JSON,
+          'Accept': ContentType.JSON,
         },
       });
     }, 10000);
@@ -588,7 +588,7 @@ describe('HTTP functions', () => {
         authenticate: false,
         method: 'GET',
         headers: {
-          'Content-Type': ContentType.JSON,
+          'Accept': ContentType.JSON,
         },
       });
     }, 10000);
@@ -650,7 +650,7 @@ describe('HTTP functions', () => {
         authenticate: false,
         method: 'GET',
         headers: {
-          'Content-Type': ContentType.JSON,
+          'Accept': ContentType.JSON,
         },
       });
     }, 10000);
@@ -678,7 +678,7 @@ describe('HTTP functions', () => {
         authenticate: false,
         method: 'GET',
         headers: {
-          'Content-Type': ContentType.JSON,
+          'Accept': ContentType.JSON,
         },
       });
     }, 10000);

--- a/src/test/utils.ts
+++ b/src/test/utils.ts
@@ -144,7 +144,7 @@ export async function mockResponsesForProvider(
 
   await server
     .forGet('/providers/' + provider)
-    .withHeaders({ 'Content-Type': ContentType.JSON })
+    .withHeaders({ 'Accept': ContentType.JSON })
     .thenJson(200, mockProviderResponse);
 }
 
@@ -172,7 +172,7 @@ export async function mockResponsesForProfileProviders(
   await server
     .forGet('/providers')
     .withQuery({ profile: profile })
-    .withHeaders({ 'Content-Type': ContentType.JSON })
+    .withHeaders({ 'Accept': ContentType.JSON })
     .thenJson(200, { data: providersInfo });
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -772,10 +772,10 @@
     debug "^4.3.3"
     typescript "^4"
 
-"@superfaceai/service-client@^5.0.0":
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/@superfaceai/service-client/-/service-client-5.2.0.tgz#462ebe71c7c0ddf7db95d0f5f567537ba5a86141"
-  integrity sha512-CSecvuJMrmwETh2HUs7X3DNy0dNp+rNnsk6eAeqTZN78/YhsE+yIJcFbTu88G8QVI7YhtAjZdTdlBkGxNFWidA==
+"@superfaceai/service-client@5.2.1":
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/@superfaceai/service-client/-/service-client-5.2.1.tgz#4de70a0efbd09e8fd22eefc1897562672bf7183b"
+  integrity sha512-S9blDBr1/kLDpelO0bymU58ZEViWUayYC41ey1EcxtPn4tdUMjAkOQb30wpZYK56bU2ywXF3sn/FyzJVkP5akg==
   dependencies:
     cross-fetch "^3.1.5"
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
<!--- Describe your changes in detail -->
This PR updates @superfaceai/service-client to v5.2.1 with fixed getProvidersList, getProvider and getUserInfo methods which did not set `Accept` header.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Upcoming versions of Superface services API will not accept request without `Accept` header set.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
