### PR TITLE
feat: provider state checks

### DIFF
--- a/src/commands/map.test.ts
+++ b/src/commands/map.test.ts
@@ -212,6 +212,28 @@ describe('MapCLI command', () => {
           `Provider name in provider.json file does not match provider name in command.`
         );
       });
+
+      it('throws when provider defines only url with TODO', async () => {
+        jest.mocked(exists).mockResolvedValueOnce(true);
+        const providerJson = mockProviderJson({ name: 'test' });
+        providerJson.services[0].baseUrl = 'https://TODO.com';
+        jest
+          .mocked(readFile)
+          .mockResolvedValueOnce(JSON.stringify(providerJson));
+        await expect(
+          instance.execute({
+            logger,
+            userError,
+            flags: {},
+            args: {
+              providerName: 'test',
+              profileId: `${profileScope}.${profileName}`,
+            },
+          })
+        ).rejects.toThrow(
+          `Provider.json file is not properly configured. Please make sure to replace 'TODO' in baseUrl with the actual base url of the API.`
+        );
+      });
     });
 
     describe('checking profile id argument', () => {

--- a/src/commands/map.test.ts
+++ b/src/commands/map.test.ts
@@ -214,11 +214,16 @@ describe('MapCLI command', () => {
       });
 
       it('throws when provider defines only url with TODO', async () => {
-        jest.mocked(exists).mockResolvedValueOnce(true);
+        jest
+          .mocked(exists)
+          .mockResolvedValueOnce(true)
+          .mockResolvedValueOnce(true);
+
         const providerJson = mockProviderJson({ name: 'test' });
         providerJson.services[0].baseUrl = 'https://TODO.com';
         jest
           .mocked(readFile)
+          .mockResolvedValueOnce(profileSource(profileScope, profileName))
           .mockResolvedValueOnce(JSON.stringify(providerJson));
         await expect(
           instance.execute({
@@ -227,7 +232,7 @@ describe('MapCLI command', () => {
             flags: {},
             args: {
               providerName: 'test',
-              profileId: `${profileScope}.${profileName}`,
+              profileId: `${profileScope}/${profileName}`,
             },
           })
         ).rejects.toThrow(

--- a/src/commands/new.test.ts
+++ b/src/commands/new.test.ts
@@ -157,6 +157,23 @@ describe('new CLI command', () => {
       );
     });
 
+    it('throws when provider defines only url with TODO', async () => {
+      jest.mocked(exists).mockResolvedValueOnce(true);
+      const providerJson = mockProviderJson({ name: 'test' });
+      providerJson.services[0].baseUrl = 'https://TODO.com';
+      jest.mocked(readFile).mockResolvedValueOnce(JSON.stringify(providerJson));
+      await expect(
+        instance.execute({
+          logger,
+          userError,
+          flags: {},
+          args: { providerName: 'test', prompt: 'test' },
+        })
+      ).rejects.toThrow(
+        `Provider.json file is not properly configured. Please make sure to replace 'TODO' in baseUrl with the actual base url of the API.`
+      );
+    });
+
     it('throws when profile already exists', async () => {
       const providerName = 'test';
       const profileName = 'test';

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -189,5 +189,15 @@ export async function resolveProviderJson(
     );
   }
 
+  if (
+    providerJson.services.length === 1 &&
+    providerJson.services[0].baseUrl.includes('TODO')
+  ) {
+    throw userError(
+      `Provider.json file is not properly configured. Please make sure to replace 'TODO' in baseUrl with the actual base url of the API.`,
+      1
+    );
+  }
+
   return providerJson;
 }

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -120,7 +120,18 @@ This command prepares a Provider JSON metadata definition that can be used to ge
       { userError, ux }
     );
 
-    ux.succeed('Provider definition successfully prepared');
+    if (
+      providerJson.services.length === 0 ||
+      (providerJson.services.length === 1 &&
+        providerJson.services[0].baseUrl.includes('TODO'))
+    ) {
+      // TODO: provide more info - url to docs
+      ux.warn(
+        'Provider definition prepared, but some parts are missing. Please fill them manually.'
+      );
+    } else {
+      ux.succeed('Provider definition successfully prepared');
+    }
 
     ux.start('Saving provider definition');
     await writeProviderJson(providerJson, { logger, userError });


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR adds check of provider state:
If server returns empty ProviderJson user will get warn message 
If user tries to use empty ProviderJson in new or map command he will get error pointing to provider json. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
