### PR TITLE
feat: README update

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Superface s.r.o.
+Copyright (c) 2023 Superface s.r.o.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,25 +1,14 @@
-# CLI
+
+<img src="https://github.com/superfaceai/cli/blob/main/docs/LogoGreen.png" alt="superface logo" width="100" height="100">
+
+# Superface CLI
+
+**Let AI connect the APIs for you.**
 
 [![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/superfaceai/cli/main.yml)](https://github.com/superfaceai/cli/actions/workflows/main.yml)
-![NPM](https://img.shields.io/npm/v/@superfaceai/cli)
+[![Stable Release](https://img.shields.io/github/v/release/superfaceai/cli?label=homebrew)](#install)
 [![NPM](https://img.shields.io/npm/l/@superfaceai/cli)](LICENSE)
 ![TypeScript](https://img.shields.io/badge/%3C%2F%3E-Typescript-blue)
-
-<img src="https://github.com/superfaceai/cli/blob/main/docs/LogoGreen.png" alt="superface logo" width="150" height="150">
-
-Superface CLI provides access to superface tooling from the CLI.
-
-## Table of Contents
-
-- [Background](#background)
-- [Install](#install)
-- [Usage](#usage)
-- [Security](#security)
-- [Support](#support)
-- [Development](#development)
-- [Maintainers](#maintainers)
-- [Contributing](#contributing)
-- [License](#license)
 
 ## Background
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[Website](https://superface.ai) | [Get Started](https://superface.ai/docs/introduction/getting-started) | [Documentation](https://superface.ai/docs) | [Discord](https://sfc.is/discord) | [Twitter](https://twitter.com/superfaceai) | [Support](https://superface.ai/support)
 
 <img src="https://github.com/superfaceai/cli/blob/main/docs/LogoGreen.png" alt="superface logo" width="100" height="100">
 
@@ -278,10 +279,6 @@ _See code: [src/commands/whoami.ts](https://github.com/superfaceai/cli/tree/main
 Superface is not man-in-the-middle so it does not require any access to secrets that are needed to communicate with provider API. Superface CLI only prepares super.json file with authorization fields in form of environment variable. You just set correct variables and communicate directly with provider API.
 
 You can find more information in [SDK repository](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md).
-
-## Support
-
-If you need any additional support, have any questions or you just want to talk you can do that through our [documentation page](https://docs.superface.ai).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -24,21 +24,10 @@ You can get more information at https://superface.ai and https://superface.ai/do
 
 ## Install
 
-To install this package, just install the cli globally using one of the following commands:
+[Install Homebrew](https://brew.sh/), then install Superface CLI with:
 
 ```shell
-# if using yarn
-yarn global add @superfaceai/cli
-# otherwise
-npm install --global @superfaceai/cli
-```
-
-Or you can use NPX directly with Superface CLI commands:
-
-```shell
-npx @superfaceai/cli [command]
-# eg.
-npx @superfaceai/cli install [profileId eg. communication/send-email]
+brew install superfaceai/cli/superface
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -11,17 +11,10 @@
 [![NPM](https://img.shields.io/npm/l/@superfaceai/cli)](LICENSE)
 ![TypeScript](https://img.shields.io/badge/%3C%2F%3E-Typescript-blue)
 
-## Background
-
-Superface (super-interface) is a higher-order API, an abstraction on top of modern APIs like GraphQL and REST. Superface gives you the one interface to discover, connect, and query any capabilities available via conventional APIs.
-
-Through its focus on application-level semantics, Superface decouples the clients from servers, enabling fully autonomous evolution. As such, it minimizes the code base as well as errors and downtimes while providing unmatched resiliency and redundancy.
-
-Superface allows for switching providers at runtime in milliseconds with no development cost. Furthermore, Superface decentralizes the composition and aggregation of integrations, and thus creates an Autonomous Integration Mesh.
-
-Motivation behind Superface is nicely described in this [video](https://www.youtube.com/watch?v=BCvq3NXFb94) from APIdays conference.
-
-You can get more information at https://superface.ai and https://superface.ai/docs.
+Superface CLI abstracts APIs into the business cases you need. Point at API docs,
+state your desired use case, let AI create an integration code, then use it
+in your application. You remain in control of the code, and your app communicates
+directly with your chosen APIs without any middlemen or proxy.
 
 ## Install
 
@@ -34,13 +27,19 @@ brew install superfaceai/cli/superface
 ## Usage
 
   <!-- commands -->
-* [`superface execute PROVIDERNAME PROFILEID`](#superface-execute-providername-profileid)
-* [`superface login`](#superface-login)
-* [`superface logout`](#superface-logout)
-* [`superface map PROVIDERNAME [PROFILEID]`](#superface-map-providername-profileid)
-* [`superface new PROVIDERNAME [PROMPT]`](#superface-new-providername-prompt)
-* [`superface prepare URLORPATH [NAME]`](#superface-prepare-urlorpath-name)
-* [`superface whoami`](#superface-whoami)
+- [Superface CLI](#superface-cli)
+  - [Install](#install)
+  - [Usage](#usage)
+  - [`superface execute PROVIDERNAME PROFILEID`](#superface-execute-providername-profileid)
+  - [`superface login`](#superface-login)
+  - [`superface logout`](#superface-logout)
+  - [`superface map PROVIDERNAME [PROFILEID]`](#superface-map-providername-profileid)
+  - [`superface new PROVIDERNAME [PROMPT]`](#superface-new-providername-prompt)
+  - [`superface prepare URLORPATH [NAME]`](#superface-prepare-urlorpath-name)
+  - [`superface whoami`](#superface-whoami)
+  - [Development](#development)
+  - [Contributing](#contributing)
+  - [License](#license)
 
 ## `superface execute PROVIDERNAME PROFILEID`
 

--- a/README.md
+++ b/README.md
@@ -274,12 +274,6 @@ _See code: [src/commands/whoami.ts](https://github.com/superfaceai/cli/tree/main
 
 <!-- commandsstop -->
 
-## Security
-
-Superface is not man-in-the-middle so it does not require any access to secrets that are needed to communicate with provider API. Superface CLI only prepares super.json file with authorization fields in form of environment variable. You just set correct variables and communicate directly with provider API.
-
-You can find more information in [SDK repository](https://github.com/superfaceai/one-sdk-js/blob/main/SECURITY.md).
-
 ## Development
 
 When developing, start with cloning the repository using `git clone https://github.com/superfaceai/cli.git` (or `git clone git@github.com:superfaceai/cli.git` if you have repository access).

--- a/README.md
+++ b/README.md
@@ -332,13 +332,6 @@ To install a local artifact globally, symlink the binary (`ln -s bin/superface <
 
 **Note**: You can change url of API requests by setting `SUPERFACE_API_URL` environment variable to desired base url.
 
-## Maintainers
-
-- [@Lukáš Valenta](https://github.com/lukas-valenta)
-- [@Edward](https://github.com/TheEdward162)
-- [@Vratislav Kalenda](https://github.com/Vratislav)
-- [@Z](https://github.com/zdne)
-
 ## Contributing
 
 **Please open an issue first if you want to make larger changes**

--- a/README.md
+++ b/README.md
@@ -11,17 +11,10 @@
 [![NPM](https://img.shields.io/npm/l/@superfaceai/cli)](LICENSE)
 ![TypeScript](https://img.shields.io/badge/%3C%2F%3E-Typescript-blue)
 
-## Background
-
-Superface (super-interface) is a higher-order API, an abstraction on top of modern APIs like GraphQL and REST. Superface gives you the one interface to discover, connect, and query any capabilities available via conventional APIs.
-
-Through its focus on application-level semantics, Superface decouples the clients from servers, enabling fully autonomous evolution. As such, it minimizes the code base as well as errors and downtimes while providing unmatched resiliency and redundancy.
-
-Superface allows for switching providers at runtime in milliseconds with no development cost. Furthermore, Superface decentralizes the composition and aggregation of integrations, and thus creates an Autonomous Integration Mesh.
-
-Motivation behind Superface is nicely described in this [video](https://www.youtube.com/watch?v=BCvq3NXFb94) from APIdays conference.
-
-You can get more information at https://superface.ai and https://superface.ai/docs.
+Superface CLI abstracts APIs into the business cases you need. Point at API docs,
+state your desired use case, let AI create an integration code, then use it
+in your application. You remain in control of the code, and your app communicates
+directly with your chosen APIs without any middlemen or proxy.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -11,10 +11,17 @@
 [![NPM](https://img.shields.io/npm/l/@superfaceai/cli)](LICENSE)
 ![TypeScript](https://img.shields.io/badge/%3C%2F%3E-Typescript-blue)
 
-Superface CLI abstracts APIs into the business cases you need. Point at API docs,
-state your desired use case, let AI create an integration code, then use it
-in your application. You remain in control of the code, and your app communicates
-directly with your chosen APIs without any middlemen or proxy.
+## Background
+
+Superface (super-interface) is a higher-order API, an abstraction on top of modern APIs like GraphQL and REST. Superface gives you the one interface to discover, connect, and query any capabilities available via conventional APIs.
+
+Through its focus on application-level semantics, Superface decouples the clients from servers, enabling fully autonomous evolution. As such, it minimizes the code base as well as errors and downtimes while providing unmatched resiliency and redundancy.
+
+Superface allows for switching providers at runtime in milliseconds with no development cost. Furthermore, Superface decentralizes the composition and aggregation of integrations, and thus creates an Autonomous Integration Mesh.
+
+Motivation behind Superface is nicely described in this [video](https://www.youtube.com/watch?v=BCvq3NXFb94) from APIdays conference.
+
+You can get more information at https://superface.ai and https://superface.ai/docs.
 
 ## Install
 
@@ -27,19 +34,13 @@ brew install superfaceai/cli/superface
 ## Usage
 
   <!-- commands -->
-- [Superface CLI](#superface-cli)
-  - [Install](#install)
-  - [Usage](#usage)
-  - [`superface execute PROVIDERNAME PROFILEID`](#superface-execute-providername-profileid)
-  - [`superface login`](#superface-login)
-  - [`superface logout`](#superface-logout)
-  - [`superface map PROVIDERNAME [PROFILEID]`](#superface-map-providername-profileid)
-  - [`superface new PROVIDERNAME [PROMPT]`](#superface-new-providername-prompt)
-  - [`superface prepare URLORPATH [NAME]`](#superface-prepare-urlorpath-name)
-  - [`superface whoami`](#superface-whoami)
-  - [Development](#development)
-  - [Contributing](#contributing)
-  - [License](#license)
+* [`superface execute PROVIDERNAME PROFILEID`](#superface-execute-providername-profileid)
+* [`superface login`](#superface-login)
+* [`superface logout`](#superface-logout)
+* [`superface map PROVIDERNAME [PROFILEID]`](#superface-map-providername-profileid)
+* [`superface new PROVIDERNAME [PROMPT]`](#superface-new-providername-prompt)
+* [`superface prepare URLORPATH [NAME]`](#superface-prepare-urlorpath-name)
+* [`superface whoami`](#superface-whoami)
 
 ## `superface execute PROVIDERNAME PROFILEID`
 

--- a/README.md
+++ b/README.md
@@ -362,5 +362,5 @@ Note: If editing the README, please conform to the [standard-readme](https://git
 
 ## License
 
-The Superface is licensed under the [MIT](LICENSE).
-© 2021 Superface
+The Superface CLI is licensed under the [MIT](LICENSE).
+© 2023 Superface


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
Updating CLI README, [preview in branch](https://github.com/superfaceai/cli/tree/feat/x-new-readme#readme):
- [x] updated license year
- [x] removed Maintainers section (is irrelevant)
- [x] updated header to use `homebrew` badge instead of `npm`
- [x] updated header to correspond better with [OneSDK repo](https://github.com/superfaceai/one-sdk)
- [x] added links to home, docs, support etc in the header
- [x] removed Support section, now linked in header
- [x] updated installation command
- [x] review/remove Security section (irrelevant now, the docs has guide on setting API keys)
- [x] review Background section

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
