### PR TITLE
fix: path checking

### DIFF
--- a/src/commands/execute.test.ts
+++ b/src/commands/execute.test.ts
@@ -1,5 +1,6 @@
 import { MockLogger } from '../common';
 import { createUserError } from '../common/error';
+import { buildProviderPath } from '../common/file-structure';
 import { exists, readFile } from '../common/io';
 import { OutputStream } from '../common/output-stream';
 import { execute } from '../logic/execution';
@@ -116,7 +117,9 @@ describe('execute CLI command', () => {
             args: { providerName: 'test', profileId: 'test' },
           })
         ).rejects.toThrow(
-          'Provider test does not exist. Make sure to run "sf prepare" before running this command.'
+          `Provider test does not exist at ${buildProviderPath(
+            'test'
+          )}. Make sure to run "sf prepare" before running this command.`
         );
       });
 

--- a/src/commands/map.test.ts
+++ b/src/commands/map.test.ts
@@ -2,6 +2,7 @@ import { parseProfile, Source } from '@superfaceai/parser';
 
 import { MockLogger } from '../common';
 import { createUserError } from '../common/error';
+import { buildProviderPath } from '../common/file-structure';
 import { exists, readFile } from '../common/io';
 import { OutputStream } from '../common/output-stream';
 import { UX } from '../common/ux';
@@ -124,7 +125,9 @@ describe('MapCLI command', () => {
             },
           })
         ).rejects.toThrow(
-          'Provider test does not exist. Make sure to run "sf prepare" before running this command.'
+          `Provider test does not exist at ${buildProviderPath(
+            'test'
+          )}. Make sure to run "sf prepare" before running this command.`
         );
       });
 

--- a/src/commands/map.ts
+++ b/src/commands/map.ts
@@ -131,7 +131,7 @@ export default class Map extends Command {
     );
     ux.succeed(
       boilerplate.saved
-        ? `Boilerplate code prepared for ${resolvedLanguage} at ${boilerplate.path}.`
+        ? `Boilerplate code prepared for ${resolvedLanguage} at ${boilerplate.path}`
         : `Boilerplate for ${resolvedLanguage} code already exists at ${boilerplate.path}.`
     );
 

--- a/src/commands/new.test.ts
+++ b/src/commands/new.test.ts
@@ -1,5 +1,6 @@
 import { MockLogger } from '../common';
 import { createUserError } from '../common/error';
+import { buildProviderPath } from '../common/file-structure';
 import { exists, readFile } from '../common/io';
 import { OutputStream } from '../common/output-stream';
 import { UX } from '../common/ux';
@@ -95,7 +96,9 @@ describe('new CLI command', () => {
           args: { providerName: 'test', prompt: 'test' },
         })
       ).rejects.toThrow(
-        'Provider test does not exist. Make sure to run "sf prepare" before running this command.'
+        `Provider test does not exist at ${buildProviderPath(
+          'test'
+        )}. Make sure to run "sf prepare" before running this command.`
       );
     });
 

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -157,9 +157,10 @@ export async function resolveProviderJson(
     throw userError('Invalid provider name', 1);
   }
 
-  if (!(await exists(buildProviderPath(providerName)))) {
+  const path = buildProviderPath(providerName);
+  if (!(await exists(path))) {
     throw userError(
-      `Provider ${providerName} does not exist. Make sure to run "sf prepare" before running this command.`,
+      `Provider ${providerName} does not exist at ${path}. Make sure to run "sf prepare" before running this command.`,
       1
     );
   }

--- a/src/common/file-structure.ts
+++ b/src/common/file-structure.ts
@@ -11,6 +11,10 @@ const PROVIDER_EXTENSION = '.provider.json';
 const MAP_EXTENSION = '.map.js';
 
 export function buildSuperfaceDirPath(): string {
+  // If user is in superface dir, use it
+  if (process.cwd().endsWith('/' + DEFAULT_SUPERFACE_DIR))
+    return resolve(process.cwd());
+
   return join(resolve(process.cwd()), DEFAULT_SUPERFACE_DIR);
 }
 
@@ -19,18 +23,13 @@ export function buildProfilePath(
   name: string
 ): string {
   return join(
-    resolve(process.cwd()),
-    DEFAULT_SUPERFACE_DIR,
+    buildSuperfaceDirPath(),
     `${scope !== undefined ? `${scope}.` : ''}${name}${PROFILE_EXTENSION}`
   );
 }
 
 export function buildProviderPath(providerName: string): string {
-  return join(
-    resolve(process.cwd()),
-    DEFAULT_SUPERFACE_DIR,
-    `${providerName}${PROVIDER_EXTENSION}`
-  );
+  return join(buildSuperfaceDirPath(), `${providerName}${PROVIDER_EXTENSION}`);
 }
 
 export function buildMapPath({
@@ -43,8 +42,7 @@ export function buildMapPath({
   providerName: string;
 }): string {
   return join(
-    resolve(process.cwd()),
-    DEFAULT_SUPERFACE_DIR,
+    buildSuperfaceDirPath(),
     `${
       profileScope !== undefined ? `${profileScope}.` : ''
     }${profileName}.${providerName}${MAP_EXTENSION}`
@@ -70,8 +68,7 @@ export function buildRunFilePath({
   const extension = EXTENSION_MAP[language];
 
   return join(
-    resolve(process.cwd()),
-    DEFAULT_SUPERFACE_DIR,
+    buildSuperfaceDirPath(),
     `${
       profileScope !== undefined ? `${profileScope}.` : ''
     }${profileName}.${providerName}${extension}`
@@ -86,9 +83,5 @@ export function buildProjectDefinitionFilePath(
     python: 'requirements.txt',
   };
 
-  return join(
-    resolve(process.cwd()),
-    DEFAULT_SUPERFACE_DIR,
-    FILENAME_MAP[language]
-  );
+  return join(buildSuperfaceDirPath(), FILENAME_MAP[language]);
 }

--- a/src/logic/project/js/js.test.ts
+++ b/src/logic/project/js/js.test.ts
@@ -32,7 +32,11 @@ describe('prepareJsProject', () => {
 
     await expect(
       prepareJsProject('3.0.0-alpha.12', '^16.0.3')
-    ).resolves.toEqual({ saved: true, installationGuide: expect.any(String), path: expect.stringContaining('superface/package.json') });
+    ).resolves.toEqual({
+      saved: true,
+      installationGuide: expect.any(String),
+      path: expect.stringContaining('superface/package.json'),
+    });
 
     expect(mockWriteOnce).toHaveBeenCalledWith(
       buildProjectDefinitionFilePath(SupportedLanguages.JS),
@@ -45,7 +49,11 @@ describe('prepareJsProject', () => {
 
     await expect(
       prepareJsProject('3.0.0-alpha.12', '^16.0.3')
-    ).resolves.toEqual({ saved: false, installationGuide: expect.any(String), path: expect.stringContaining('superface/package.json') });
+    ).resolves.toEqual({
+      saved: false,
+      installationGuide: expect.any(String),
+      path: expect.stringContaining('superface/package.json'),
+    });
 
     expect(mockWriteOnce).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR allows CLI to locate local files even when user is in Superface folder. This is useful when running execute command after dependencies installation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
