### PR TITLE
feat: execute location check

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ brew install superfaceai/cli/superface
 
 ## `superface execute PROVIDERNAME PROFILEID`
 
-Run the created integration. Commands `prepare`, `new` and `map` must be run before this command. This command will execute integration using Node.js (more runners coming soon)
+Run the created integration in superface directory. Commands `prepare`, `new` and `map` must be run before this command. This command will execute integration using Node.js (more runners coming soon)
 
 ```
 USAGE

--- a/src/commands/execute.test.ts
+++ b/src/commands/execute.test.ts
@@ -1,5 +1,6 @@
 import { MockLogger } from '../common';
 import { createUserError } from '../common/error';
+import { isInsideSuperfaceDir } from '../common/file-structure';
 import { exists, readFile } from '../common/io';
 import { OutputStream } from '../common/output-stream';
 import { execute } from '../logic/execution';
@@ -10,6 +11,11 @@ import Execute from './execute';
 jest.mock('../common/io');
 jest.mock('../common/output-stream');
 jest.mock('../logic/execution');
+
+jest.mock('../common/file-structure', () => ({
+  ...jest.requireActual('../common/file-structure'),
+  isInsideSuperfaceDir: jest.fn(),
+}));
 
 describe('execute CLI command', () => {
   const providerName = 'provider-name';
@@ -65,8 +71,29 @@ describe('execute CLI command', () => {
     });
 
     describe('checking language argument', () => {
+      it('throws when cwd is not in superface folder', async () => {
+        jest.mocked(exists).mockResolvedValueOnce(true);
+        jest.mocked(isInsideSuperfaceDir).mockReturnValue(false);
+        jest
+          .mocked(readFile)
+          .mockResolvedValueOnce(JSON.stringify(providerJson));
+        await expect(
+          instance.execute({
+            logger,
+            userError,
+            flags: {},
+            args: {
+              providerName,
+              profileId: profileName,
+              language: 'python',
+            },
+          })
+        ).rejects.toThrow('Command must be run inside superface directory');
+      });
+
       it('throws when language is invalid', async () => {
         jest.mocked(exists).mockResolvedValueOnce(true);
+        jest.mocked(isInsideSuperfaceDir).mockReturnValue(true);
         jest
           .mocked(readFile)
           .mockResolvedValueOnce(JSON.stringify(providerJson));
@@ -90,6 +117,7 @@ describe('execute CLI command', () => {
     describe('checking profile id argument', () => {
       it('throws when profile id is not provided', async () => {
         jest.mocked(exists).mockResolvedValueOnce(true);
+        jest.mocked(isInsideSuperfaceDir).mockReturnValue(true);
         jest
           .mocked(readFile)
           .mockResolvedValueOnce(JSON.stringify(providerJson));
@@ -107,6 +135,7 @@ describe('execute CLI command', () => {
 
       it('throws when profile id is invalid', async () => {
         jest.mocked(exists).mockResolvedValueOnce(true);
+        jest.mocked(isInsideSuperfaceDir).mockReturnValue(true);
         jest
           .mocked(readFile)
           .mockResolvedValueOnce(JSON.stringify(providerJson));
@@ -127,6 +156,8 @@ describe('execute CLI command', () => {
           .mocked(exists)
           .mockResolvedValueOnce(true)
           .mockResolvedValueOnce(false);
+        jest.mocked(isInsideSuperfaceDir).mockReturnValue(true);
+
         jest
           .mocked(readFile)
           .mockResolvedValueOnce(JSON.stringify(providerJson));
@@ -147,6 +178,8 @@ describe('execute CLI command', () => {
           .mocked(exists)
           .mockResolvedValueOnce(true)
           .mockResolvedValueOnce(true);
+        jest.mocked(isInsideSuperfaceDir).mockReturnValue(true);
+
         jest
           .mocked(readFile)
           .mockRejectedValueOnce(new Error('File read error'));
@@ -165,6 +198,7 @@ describe('execute CLI command', () => {
           .mocked(exists)
           .mockResolvedValueOnce(true)
           .mockResolvedValueOnce(true);
+        jest.mocked(isInsideSuperfaceDir).mockReturnValue(true);
         jest
           .mocked(readFile)
           .mockResolvedValueOnce(JSON.stringify(providerJson))
@@ -184,6 +218,7 @@ describe('execute CLI command', () => {
           .mocked(exists)
           .mockResolvedValueOnce(true)
           .mockResolvedValueOnce(true);
+        jest.mocked(isInsideSuperfaceDir).mockReturnValue(true);
         jest
           .mocked(readFile)
           .mockResolvedValueOnce(JSON.stringify(providerJson))
@@ -206,6 +241,7 @@ describe('execute CLI command', () => {
           .mocked(exists)
           .mockResolvedValueOnce(true)
           .mockResolvedValueOnce(true);
+        jest.mocked(isInsideSuperfaceDir).mockReturnValue(true);
         jest
           .mocked(readFile)
           .mockResolvedValueOnce(JSON.stringify(providerJson))
@@ -230,6 +266,7 @@ describe('execute CLI command', () => {
         .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(false);
+      jest.mocked(isInsideSuperfaceDir).mockReturnValue(true);
       jest
         .mocked(readFile)
         .mockResolvedValueOnce(JSON.stringify(providerJson))
@@ -247,6 +284,7 @@ describe('execute CLI command', () => {
 
     it('executes runfile - profile with scope', async () => {
       jest.mocked(exists).mockResolvedValue(true);
+      jest.mocked(isInsideSuperfaceDir).mockReturnValue(true);
       jest
         .mocked(readFile)
         .mockResolvedValueOnce(JSON.stringify(providerJson))
@@ -275,6 +313,7 @@ describe('execute CLI command', () => {
 
     it('executes runfile - profile without scope', async () => {
       jest.mocked(exists).mockResolvedValue(true);
+      jest.mocked(isInsideSuperfaceDir).mockReturnValue(true);
       jest
         .mocked(readFile)
         .mockResolvedValueOnce(JSON.stringify(providerJson))

--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -2,7 +2,11 @@ import type { ILogger } from '../common';
 import type { Flags } from '../common/command.abstract';
 import { Command } from '../common/command.abstract';
 import type { UserError } from '../common/error';
-import { buildMapPath, buildRunFilePath } from '../common/file-structure';
+import {
+  buildMapPath,
+  buildRunFilePath,
+  isInsideSuperfaceDir,
+} from '../common/file-structure';
 import { SuperfaceClient } from '../common/http';
 import { exists } from '../common/io';
 import { ProfileId } from '../common/profile';
@@ -15,7 +19,7 @@ import { resolveLanguage, resolveProfileSource } from './map';
 export default class Execute extends Command {
   // TODO: add description
   public static description =
-    'Run the created integration. Commands `prepare`, `new` and `map` must be run before this command. This command will execute integration using Node.js (more runners coming soon)';
+    'Run the created integration in superface directory. Commands `prepare`, `new` and `map` must be run before this command. This command will execute integration using Node.js (more runners coming soon)';
 
   public static examples = [
     'superface execute resend communication/send-email',
@@ -74,6 +78,9 @@ export default class Execute extends Command {
     const ux = UX.create();
     const { providerName, profileId, language } = args;
 
+    if (!isInsideSuperfaceDir()) {
+      throw userError('Command must be run inside superface directory', 1);
+    }
     const resolvedLanguage = resolveLanguage(language, { userError });
 
     ux.start('Loading provider definition');

--- a/src/common/file-structure.ts
+++ b/src/common/file-structure.ts
@@ -10,6 +10,10 @@ const PROVIDER_EXTENSION = '.provider.json';
 
 const MAP_EXTENSION = '.map.js';
 
+export function isInsideSuperfaceDir(): boolean {
+  return process.cwd().endsWith('/' + DEFAULT_SUPERFACE_DIR);
+}
+
 export function buildSuperfaceDirPath(): string {
   // If user is in superface dir, use it
   if (process.cwd().endsWith('/' + DEFAULT_SUPERFACE_DIR))


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR adds check that throws error when `execute` command is not run from superface directory.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
