### PR TITLE
feat: Using `beta` tag for JS OneSDK dependency

### DIFF
--- a/src/logic/project/js/js.ts
+++ b/src/logic/project/js/js.ts
@@ -4,7 +4,8 @@ import { OutputStream } from '../../../common/output-stream';
 import { SupportedLanguages } from '../../application-code';
 
 export async function prepareJsProject(
-  sdkVerion = '3.0.0-alpha.12',
+  // https://www.npmjs.com/package/@superfaceai/one-sdk?activeTab=versions
+  sdkVerion = 'beta', // get latest beta using the `beta` tag
   dotenvVersion = '^16.0.3'
 ): Promise<{
   saved: boolean;


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
The OneSDK dependency for JS boilerplate project uses `beta` version tag. This way always the latest beta will get installed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
