### PR TITLE
feat: Boilerplate code inits `.env` file

### DIFF
--- a/src/commands/map.test.ts
+++ b/src/commands/map.test.ts
@@ -5,10 +5,12 @@ import { createUserError } from '../common/error';
 import { exists, readFile } from '../common/io';
 import { OutputStream } from '../common/output-stream';
 import { UX } from '../common/ux';
+import type { NewDotenv } from '../logic';
 import {
+  createNewDotenv,
   SupportedLanguages,
   writeApplicationCode,
-} from '../logic/application-code/application-code';
+} from '../logic/application-code';
 import { mapProviderToProfile } from '../logic/map';
 import { prepareProject } from '../logic/project';
 import { mockProviderJson } from '../test/provider-json';
@@ -19,6 +21,7 @@ jest.mock('../common/io');
 jest.mock('../common/output-stream');
 jest.mock('../logic/map');
 jest.mock('../logic/application-code/application-code');
+jest.mock('../logic/application-code/dotenv');
 jest.mock('../logic/project');
 
 describe('MapCLI command', () => {
@@ -43,6 +46,10 @@ describe('MapCLI command', () => {
     code: 'mocked application code',
     requiredParameters: ['TEST_PARAMETER'],
     requiredSecurity: ['TEST_SECURITY'],
+  };
+  const mockDotenv: NewDotenv = {
+    content: 'TEST_PARAMETER=\nTEST_SECURITY=',
+    addedEnvVariables: ['TEST_PARAMETER', 'TEST_SECURITY'],
   };
   const providerJson = mockProviderJson({ name: providerName });
   const userError = createUserError(false);
@@ -255,6 +262,8 @@ describe('MapCLI command', () => {
         .mocked(writeApplicationCode)
         .mockResolvedValueOnce(mockApplicationCode);
 
+      jest.mocked(createNewDotenv).mockReturnValueOnce(mockDotenv);
+
       jest.mocked(mapProviderToProfile).mockResolvedValueOnce(mapSource);
 
       await instance.execute({
@@ -309,6 +318,8 @@ describe('MapCLI command', () => {
       jest
         .mocked(writeApplicationCode)
         .mockResolvedValueOnce(mockApplicationCode);
+
+      jest.mocked(createNewDotenv).mockReturnValueOnce(mockDotenv);
 
       jest.mocked(mapProviderToProfile).mockResolvedValueOnce(mapSource);
 
@@ -387,6 +398,8 @@ describe('MapCLI command', () => {
         .mocked(writeApplicationCode)
         .mockResolvedValueOnce(mockApplicationCode);
 
+      jest.mocked(createNewDotenv).mockReturnValueOnce(mockDotenv);
+
       await instance.execute({
         logger,
         userError,
@@ -459,6 +472,8 @@ describe('MapCLI command', () => {
       jest
         .mocked(writeApplicationCode)
         .mockResolvedValueOnce(mockApplicationCode);
+
+      jest.mocked(createNewDotenv).mockReturnValueOnce(mockDotenv);
 
       await instance.execute({
         logger,

--- a/src/common/file-structure.test.ts
+++ b/src/common/file-structure.test.ts
@@ -3,6 +3,7 @@ import {
   buildMapPath,
   buildProfilePath,
   buildProjectDefinitionFilePath,
+  buildProjectDotenvFilePath,
   buildProviderPath,
   buildRunFilePath,
   buildSuperfaceDirPath,
@@ -119,6 +120,14 @@ describe('fileStructure', () => {
     it('builds project definition file path', () => {
       expect(buildProjectDefinitionFilePath()).toEqual(
         expect.stringContaining(`/superface/package.json`)
+      );
+    });
+  });
+
+  describe('buildProjectDotenvFilePath', () => {
+    it('builds project .env file path', () => {
+      expect(buildProjectDotenvFilePath()).toEqual(
+        expect.stringContaining(`/superface/.env`)
       );
     });
   });

--- a/src/common/file-structure.ts
+++ b/src/common/file-structure.ts
@@ -89,3 +89,7 @@ export function buildProjectDefinitionFilePath(
 
   return join(buildSuperfaceDirPath(), FILENAME_MAP[language]);
 }
+
+export function buildProjectDotenvFilePath(): string {
+  return join(buildSuperfaceDirPath(), '.env');
+}

--- a/src/logic/application-code/dotenv/dotenv.test.ts
+++ b/src/logic/application-code/dotenv/dotenv.test.ts
@@ -1,0 +1,84 @@
+import type { IntegrationParameter, SecurityScheme } from '@superfaceai/ast';
+import { HttpScheme, SecurityType } from '@superfaceai/ast';
+
+import { createNewDotenv } from './dotenv';
+
+const PROVIDER_NAME = 'my-provider';
+const PARAMETER: IntegrationParameter = {
+  name: 'param-one',
+  description: 'Parameter description',
+};
+const PARAMETER_WITH_DEFAULT: IntegrationParameter = {
+  name: 'param-two',
+  default: 'us-west-1',
+  description: 'Deployment zone\nfor AWS',
+};
+const BASIC_AUTH: SecurityScheme = {
+  id: 'basic_auth',
+  type: SecurityType.HTTP,
+  scheme: HttpScheme.BASIC,
+};
+const BEARER_AUTH: SecurityScheme = {
+  id: 'bearer_auth',
+  type: SecurityType.HTTP,
+  scheme: HttpScheme.BEARER,
+};
+
+describe('createNewDotenv', () => {
+  describe('when there is no previous .env', () => {
+    it('creates valid .env when no parameters or security schemes are given', () => {
+      const result = createNewDotenv({ providerName: PROVIDER_NAME });
+
+      expect(result).toStrictEqual({
+        content: '',
+        addedEnvVariables: [],
+      });
+    });
+
+    it('creates valid .env when 2 parameters but no security schemes are given', () => {
+      const result = createNewDotenv({
+        providerName: PROVIDER_NAME,
+        parameters: [PARAMETER, PARAMETER_WITH_DEFAULT],
+      });
+
+      expect(result).toStrictEqual({
+        content: `# Parameter description
+MY_PROVIDER_PARAM_ONE=
+
+# Deployment zone
+# for AWS
+MY_PROVIDER_PARAM_TWO=us-west-1
+`,
+        addedEnvVariables: ['MY_PROVIDER_PARAM_ONE', 'MY_PROVIDER_PARAM_TWO'],
+      });
+    });
+
+    it('creates valid .env when 2 parameters and 2 security schemes are given', () => {
+      const result = createNewDotenv({
+        providerName: PROVIDER_NAME,
+        parameters: [PARAMETER, PARAMETER_WITH_DEFAULT],
+        security: [BASIC_AUTH, BEARER_AUTH],
+      });
+
+      expect(result).toStrictEqual({
+        content: `# Parameter description
+MY_PROVIDER_PARAM_ONE=
+
+# Deployment zone
+# for AWS
+MY_PROVIDER_PARAM_TWO=us-west-1
+MY_PROVIDER_USERNAME=
+MY_PROVIDER_PASSWORD=
+MY_PROVIDER_TOKEN=
+`,
+        addedEnvVariables: [
+          'MY_PROVIDER_PARAM_ONE',
+          'MY_PROVIDER_PARAM_TWO',
+          'MY_PROVIDER_USERNAME',
+          'MY_PROVIDER_PASSWORD',
+          'MY_PROVIDER_TOKEN',
+        ],
+      });
+    });
+  });
+});

--- a/src/logic/application-code/dotenv/dotenv.test.ts
+++ b/src/logic/application-code/dotenv/dotenv.test.ts
@@ -24,6 +24,12 @@ const BEARER_AUTH: SecurityScheme = {
   scheme: HttpScheme.BEARER,
 };
 
+const EXISTING_DOTENV = `# Deployment zone
+# for AWS
+MY_PROVIDER_PARAM_TWO=us-west-1
+MY_PROVIDER_TOKEN=
+`;
+
 describe('createNewDotenv', () => {
   describe('when there is no previous .env', () => {
     it('creates valid .env when no parameters or security schemes are given', () => {
@@ -77,6 +83,67 @@ MY_PROVIDER_TOKEN=
           'MY_PROVIDER_USERNAME',
           'MY_PROVIDER_PASSWORD',
           'MY_PROVIDER_TOKEN',
+        ],
+      });
+    });
+  });
+
+  describe('when there is a previous existing .env', () => {
+    it('creates valid .env when no parameters or security schemes are given', () => {
+      const result = createNewDotenv({
+        previousDotenv: EXISTING_DOTENV,
+        providerName: PROVIDER_NAME,
+      });
+
+      expect(result).toStrictEqual({
+        content: EXISTING_DOTENV,
+        addedEnvVariables: [],
+      });
+    });
+
+    it('creates valid .env when 2 parameters but no security schemes are given', () => {
+      const result = createNewDotenv({
+        previousDotenv: EXISTING_DOTENV,
+        providerName: PROVIDER_NAME,
+        parameters: [PARAMETER, PARAMETER_WITH_DEFAULT],
+      });
+
+      expect(result).toStrictEqual({
+        content: `# Deployment zone
+# for AWS
+MY_PROVIDER_PARAM_TWO=us-west-1
+MY_PROVIDER_TOKEN=
+
+# Parameter description
+MY_PROVIDER_PARAM_ONE=
+`,
+        addedEnvVariables: ['MY_PROVIDER_PARAM_ONE'],
+      });
+    });
+
+    it('creates valid .env when 2 parameters and 2 security schemes are given', () => {
+      const result = createNewDotenv({
+        previousDotenv: EXISTING_DOTENV,
+        providerName: PROVIDER_NAME,
+        parameters: [PARAMETER, PARAMETER_WITH_DEFAULT],
+        security: [BASIC_AUTH, BEARER_AUTH],
+      });
+
+      expect(result).toStrictEqual({
+        content: `# Deployment zone
+# for AWS
+MY_PROVIDER_PARAM_TWO=us-west-1
+MY_PROVIDER_TOKEN=
+
+# Parameter description
+MY_PROVIDER_PARAM_ONE=
+MY_PROVIDER_USERNAME=
+MY_PROVIDER_PASSWORD=
+`,
+        addedEnvVariables: [
+          'MY_PROVIDER_PARAM_ONE',
+          'MY_PROVIDER_USERNAME',
+          'MY_PROVIDER_PASSWORD',
         ],
       });
     });

--- a/src/logic/application-code/dotenv/dotenv.ts
+++ b/src/logic/application-code/dotenv/dotenv.ts
@@ -1,0 +1,90 @@
+import type { IntegrationParameter, SecurityScheme } from '@superfaceai/ast';
+import {
+  prepareProviderParameters,
+  prepareSecurityValues,
+} from '@superfaceai/ast';
+
+export type NewDotenv = {
+  content: string;
+  addedEnvVariables: string[];
+};
+
+type EnvVar = {
+  name: string;
+  value: string | undefined;
+  comment: string | undefined;
+};
+
+export function createNewDotenv({
+  providerName,
+  parameters,
+  security,
+}: {
+  providerName: string;
+  parameters?: IntegrationParameter[];
+  security?: SecurityScheme[];
+}): NewDotenv {
+  const parameterEnvs = getParameterEnvs(providerName, parameters);
+  const securityEnvs = getSecurityEnvs(providerName, security);
+
+  const newEnvVariables = [...parameterEnvs, ...securityEnvs];
+
+  if (newEnvVariables.length === 0) {
+    return {
+      content: '',
+      addedEnvVariables: [],
+    };
+  }
+
+  const newContent =
+    newEnvVariables.map(serializeEnvVar).join('\n').trim() + '\n';
+
+  return {
+    content: newContent,
+    addedEnvVariables: newEnvVariables.map(e => e.name),
+  };
+}
+
+function serializeEnvVar(env: EnvVar): string {
+  const comment =
+    env.comment !== undefined
+      ? '\n' +
+        env.comment
+          .split('\n')
+          .map(commentLine => `# ${commentLine}`)
+          .join('\n')
+      : '';
+
+  return `${comment ? comment + '\n' : ''}${env.name}=${env.value ?? ''}`;
+}
+
+function getParameterEnvs(
+  providerName: string,
+  parameters?: IntegrationParameter[]
+): EnvVar[] {
+  const params = parameters || [];
+
+  const parameterEnvs = prepareProviderParameters(providerName, params);
+
+  return params.map(param => ({
+    name: removeDollarSign(parameterEnvs[param.name]),
+    value: param.default ?? undefined,
+    comment: param.description ?? undefined,
+  }));
+}
+
+function getSecurityEnvs(
+  providerName: string,
+  security?: SecurityScheme[]
+): EnvVar[] {
+  const securityValues = prepareSecurityValues(providerName, security || []);
+
+  return securityValues
+    .map(({ id: _, ...securityValue }) => securityValue)
+    .flatMap(securityValue => Object.values(securityValue) as string[])
+    .map(removeDollarSign)
+    .map(name => ({ name, value: undefined, comment: undefined }));
+}
+
+const removeDollarSign = (text: string): string =>
+  text.startsWith('$') ? text.slice(1) : text;

--- a/src/logic/application-code/dotenv/index.ts
+++ b/src/logic/application-code/dotenv/index.ts
@@ -1,0 +1,1 @@
+export * from './dotenv'

--- a/src/logic/application-code/index.ts
+++ b/src/logic/application-code/index.ts
@@ -1,1 +1,2 @@
 export * from './application-code';
+export * from './dotenv';


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR adds generation of `.env` file after the boilerplate code is generated (both JS and Python). The `.env` contains provider integration params and security scheme variables that are expected in the application code.

It respects potential previous `.env` file in that it only adds variables that are missing in the previous `.env.

You can go through commit by commit.

Tasks:
- [x] Create dotenv utility that takes optional previous `.env` with provider definition and creates a new `.env` 
- [x] Integrate dotenv utility to boilerplate codegen process (interact with filesystem)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
