### PR TITLE
feat: Use OneSDK token in the boilerplate code

### DIFF
--- a/src/commands/map.test.ts
+++ b/src/commands/map.test.ts
@@ -2,6 +2,7 @@ import { parseProfile, Source } from '@superfaceai/parser';
 
 import { MockLogger } from '../common';
 import { createUserError } from '../common/error';
+import { fetchSDKToken } from '../common/http';
 import { exists, readFile } from '../common/io';
 import { OutputStream } from '../common/output-stream';
 import { UX } from '../common/ux';
@@ -19,6 +20,7 @@ import Map from './map';
 
 jest.mock('../common/io');
 jest.mock('../common/output-stream');
+jest.mock('../common/http');
 jest.mock('../logic/map');
 jest.mock('../logic/application-code/application-code');
 jest.mock('../logic/application-code/dotenv');
@@ -51,6 +53,7 @@ describe('MapCLI command', () => {
     content: 'TEST_PARAMETER=\nTEST_SECURITY=',
     addedEnvVariables: ['TEST_PARAMETER', 'TEST_SECURITY'],
   };
+  const mockToken = { token: 'sfs_b31314b7fc8...8ec1930e' };
   const providerJson = mockProviderJson({ name: providerName });
   const userError = createUserError(false);
   const ux = UX.create();
@@ -262,6 +265,7 @@ describe('MapCLI command', () => {
         .mocked(writeApplicationCode)
         .mockResolvedValueOnce(mockApplicationCode);
 
+      jest.mocked(fetchSDKToken).mockResolvedValueOnce(mockToken);
       jest.mocked(createNewDotenv).mockReturnValueOnce(mockDotenv);
 
       jest.mocked(mapProviderToProfile).mockResolvedValueOnce(mapSource);
@@ -319,6 +323,7 @@ describe('MapCLI command', () => {
         .mocked(writeApplicationCode)
         .mockResolvedValueOnce(mockApplicationCode);
 
+      jest.mocked(fetchSDKToken).mockResolvedValueOnce(mockToken);
       jest.mocked(createNewDotenv).mockReturnValueOnce(mockDotenv);
 
       jest.mocked(mapProviderToProfile).mockResolvedValueOnce(mapSource);
@@ -398,6 +403,7 @@ describe('MapCLI command', () => {
         .mocked(writeApplicationCode)
         .mockResolvedValueOnce(mockApplicationCode);
 
+      jest.mocked(fetchSDKToken).mockResolvedValueOnce(mockToken);
       jest.mocked(createNewDotenv).mockReturnValueOnce(mockDotenv);
 
       await instance.execute({
@@ -473,6 +479,7 @@ describe('MapCLI command', () => {
         .mocked(writeApplicationCode)
         .mockResolvedValueOnce(mockApplicationCode);
 
+      jest.mocked(fetchSDKToken).mockResolvedValueOnce(mockToken);
       jest.mocked(createNewDotenv).mockReturnValueOnce(mockDotenv);
 
       await instance.execute({

--- a/src/commands/map.ts
+++ b/src/commands/map.ts
@@ -11,7 +11,7 @@ import {
   buildProjectDotenvFilePath,
   buildRunFilePath,
 } from '../common/file-structure';
-import { SuperfaceClient } from '../common/http';
+import { fetchSDKToken, SuperfaceClient } from '../common/http';
 import { exists, readFile, readFileQuiet } from '../common/io';
 import type { ILogger } from '../common/log';
 import { OutputStream } from '../common/output-stream';
@@ -234,6 +234,7 @@ async function saveDotenv(
 ): Promise<{ dotenvPath: string; newEnvVariables: string[] }> {
   const dotenvPath = buildProjectDotenvFilePath();
 
+  const { token } = await fetchSDKToken();
   const existingDotenv = await readFileQuiet(dotenvPath);
 
   const newDotenv = createNewDotenv({
@@ -241,6 +242,7 @@ async function saveDotenv(
     providerName: providerJson.name,
     parameters: providerJson.parameters,
     security: providerJson.securitySchemes,
+    token,
   });
 
   if (newDotenv.content) {

--- a/src/common/http.test.ts
+++ b/src/common/http.test.ts
@@ -1,6 +1,7 @@
 import type { AstMetadata, ProviderJson } from '@superfaceai/ast';
 import { ApiKeyPlacement, HttpScheme, SecurityType } from '@superfaceai/ast';
 import { ServiceApiError, ServiceClient } from '@superfaceai/service-client';
+import { UserAccountType } from '@superfaceai/service-client/dist/interfaces/identity_api_response';
 
 import type { SuperfaceClient } from '../common/http';
 import {
@@ -11,6 +12,7 @@ import {
   fetchProfileInfo,
   fetchProviderInfo,
   fetchProviders,
+  fetchSDKToken,
   getServicesUrl,
 } from '../common/http';
 import { mockResponse } from '../test/utils';
@@ -801,5 +803,120 @@ describe('HTTP functions', () => {
         }
       );
     }, 10000);
+  });
+
+  describe('when fetching default OneSDK token', () => {
+    const ACCNT_HANDLE = 'testuser';
+    const DEFAULT_PROJECT = 'default-project';
+    const TOKEN = 'sfs_b31314b7fc8...8ec1930e';
+
+    const mockUserResponse = {
+      name: 'test.user',
+      email: 'test.user@superface.test',
+      accounts: [
+        {
+          handle: ACCNT_HANDLE,
+          type: UserAccountType.PERSONAL,
+        },
+      ],
+    };
+
+    const mockGetProjectResponse = {
+      url: `https://superface.test/projects/${ACCNT_HANDLE}/${DEFAULT_PROJECT}`,
+      name: DEFAULT_PROJECT,
+      sdk_auth_tokens: [
+        {
+          token: TOKEN,
+          created_at: '2023-07-03T13:58:08.235Z',
+        },
+      ],
+      settings: {
+        email_notifications: true,
+      },
+      created_at: '2023-07-03T13:58:08.231Z',
+    };
+
+    const mockUserError = new ServiceApiError({
+      status: 401,
+      title: 'Unauthorized',
+      detail: '',
+      instance: '/id/user',
+    });
+
+    const mockGetProjectError = new ServiceApiError({
+      status: 404,
+      instance: `/projects/${ACCNT_HANDLE}/default-projec`,
+      title: 'Project not found',
+      detail: `Project ${ACCNT_HANDLE}/default-projec doesn't exist`,
+    });
+
+    let getUserInfoSpy: jest.SpyInstance;
+    let getProjectSpy: jest.SpyInstance;
+
+    beforeEach(async () => {
+      jest.resetAllMocks();
+
+      getUserInfoSpy = jest
+        .spyOn(ServiceClient.prototype, 'getUserInfo')
+        .mockResolvedValue(mockUserResponse);
+
+      getProjectSpy = jest
+        .spyOn(ServiceClient.prototype, 'getProject')
+        .mockResolvedValue(mockGetProjectResponse);
+    });
+
+    it('returns token (obtains account handle, then fetches project by handle and name)', async () => {
+      const result = await fetchSDKToken();
+
+      expect(getUserInfoSpy).toHaveBeenCalledTimes(1);
+      expect(getProjectSpy).toHaveBeenCalledTimes(1);
+      expect(getProjectSpy).toHaveBeenCalledWith(ACCNT_HANDLE, DEFAULT_PROJECT);
+
+      expect(result).toStrictEqual({ token: TOKEN });
+    });
+
+    it('returns null as a token when obtaining account handle fails', async () => {
+      getUserInfoSpy = jest
+        .spyOn(ServiceClient.prototype, 'getUserInfo')
+        .mockRejectedValue(mockUserError);
+
+      const result = await fetchSDKToken();
+
+      expect(getUserInfoSpy).toHaveBeenCalledTimes(1);
+      expect(getProjectSpy).toHaveBeenCalledTimes(0);
+
+      expect(result).toStrictEqual({ token: null });
+    });
+
+    it('returns null as a token when fetching the project fails', async () => {
+      getProjectSpy = jest
+        .spyOn(ServiceClient.prototype, 'getProject')
+        .mockRejectedValue(mockGetProjectError);
+
+      const result = await fetchSDKToken();
+
+      expect(getUserInfoSpy).toHaveBeenCalledTimes(1);
+      expect(getProjectSpy).toHaveBeenCalledTimes(1);
+      expect(getProjectSpy).toHaveBeenCalledWith(ACCNT_HANDLE, DEFAULT_PROJECT);
+
+      expect(result).toStrictEqual({ token: null });
+    });
+
+    it('returns null as a token when the project fetched lacks tokens', async () => {
+      getProjectSpy = jest
+        .spyOn(ServiceClient.prototype, 'getProject')
+        .mockResolvedValue({
+          ...mockGetProjectResponse,
+          sdk_auth_tokens: [],
+        });
+
+      const result = await fetchSDKToken();
+
+      expect(getUserInfoSpy).toHaveBeenCalledTimes(1);
+      expect(getProjectSpy).toHaveBeenCalledTimes(1);
+      expect(getProjectSpy).toHaveBeenCalledWith(ACCNT_HANDLE, DEFAULT_PROJECT);
+
+      expect(result).toStrictEqual({ token: null });
+    });
   });
 });

--- a/src/common/http.ts
+++ b/src/common/http.ts
@@ -165,3 +165,22 @@ export async function fetchMapAST(id: {
 
   return assertMapDocumentNode(JSON.parse(response));
 }
+
+export async function fetchSDKToken(
+  defaultProjectName = 'default-project'
+): Promise<{ token: string | null }> {
+  const client = SuperfaceClient.getClient();
+
+  try {
+    const userInfo = await client.getUserInfo();
+    const accountHandle = userInfo.accounts[0].handle;
+
+    const project = await client.getProject(accountHandle, defaultProjectName);
+
+    const token = project.sdk_auth_tokens?.[0].token ?? null;
+
+    return { token };
+  } catch (_) {
+    return { token: null };
+  }
+}

--- a/src/logic/application-code/dotenv/dotenv.test.ts
+++ b/src/logic/application-code/dotenv/dotenv.test.ts
@@ -23,8 +23,10 @@ const BEARER_AUTH: SecurityScheme = {
   type: SecurityType.HTTP,
   scheme: HttpScheme.BEARER,
 };
+const TOKEN = 'sfs_b31314b7fc8...8ec1930e';
 
-const EXISTING_DOTENV = `# Deployment zone
+const EXISTING_DOTENV = `SUPERFACE_ONESDK_TOKEN=sfs_b31314b7fc8...8ec1930e
+# Deployment zone
 # for AWS
 MY_PROVIDER_PARAM_TWO=us-west-1
 MY_PROVIDER_TOKEN=
@@ -32,12 +34,28 @@ MY_PROVIDER_TOKEN=
 
 describe('createNewDotenv', () => {
   describe('when there is no previous .env', () => {
-    it('creates valid .env when no parameters or security schemes are given', () => {
+    it('creates valid .env when no token, no parameters or security schemes are given', () => {
       const result = createNewDotenv({ providerName: PROVIDER_NAME });
 
       expect(result).toStrictEqual({
-        content: '',
-        addedEnvVariables: [],
+        content: `# Set your OneSDK token to monitor your usage out-of-the-box. Get yours at https://superface.ai/app
+SUPERFACE_ONESDK_TOKEN=
+`,
+        addedEnvVariables: ['SUPERFACE_ONESDK_TOKEN'],
+      });
+    });
+
+    it('creates valid .env when valid token but no parameters or security schemes are given', () => {
+      const result = createNewDotenv({
+        providerName: PROVIDER_NAME,
+        token: TOKEN,
+      });
+
+      expect(result).toStrictEqual({
+        content: `# OneSDK token lets your monitor your usage out-of-the-box at https://superface.ai/app
+SUPERFACE_ONESDK_TOKEN=sfs_b31314b7fc8...8ec1930e
+`,
+        addedEnvVariables: ['SUPERFACE_ONESDK_TOKEN'],
       });
     });
 
@@ -45,17 +63,25 @@ describe('createNewDotenv', () => {
       const result = createNewDotenv({
         providerName: PROVIDER_NAME,
         parameters: [PARAMETER, PARAMETER_WITH_DEFAULT],
+        token: TOKEN,
       });
 
       expect(result).toStrictEqual({
-        content: `# Parameter description
+        content: `# OneSDK token lets your monitor your usage out-of-the-box at https://superface.ai/app
+SUPERFACE_ONESDK_TOKEN=sfs_b31314b7fc8...8ec1930e
+
+# Parameter description
 MY_PROVIDER_PARAM_ONE=
 
 # Deployment zone
 # for AWS
 MY_PROVIDER_PARAM_TWO=us-west-1
 `,
-        addedEnvVariables: ['MY_PROVIDER_PARAM_ONE', 'MY_PROVIDER_PARAM_TWO'],
+        addedEnvVariables: [
+          'SUPERFACE_ONESDK_TOKEN',
+          'MY_PROVIDER_PARAM_ONE',
+          'MY_PROVIDER_PARAM_TWO',
+        ],
       });
     });
 
@@ -64,10 +90,14 @@ MY_PROVIDER_PARAM_TWO=us-west-1
         providerName: PROVIDER_NAME,
         parameters: [PARAMETER, PARAMETER_WITH_DEFAULT],
         security: [BASIC_AUTH, BEARER_AUTH],
+        token: TOKEN,
       });
 
       expect(result).toStrictEqual({
-        content: `# Parameter description
+        content: `# OneSDK token lets your monitor your usage out-of-the-box at https://superface.ai/app
+SUPERFACE_ONESDK_TOKEN=sfs_b31314b7fc8...8ec1930e
+
+# Parameter description
 MY_PROVIDER_PARAM_ONE=
 
 # Deployment zone
@@ -78,6 +108,7 @@ MY_PROVIDER_PASSWORD=
 MY_PROVIDER_TOKEN=
 `,
         addedEnvVariables: [
+          'SUPERFACE_ONESDK_TOKEN',
           'MY_PROVIDER_PARAM_ONE',
           'MY_PROVIDER_PARAM_TWO',
           'MY_PROVIDER_USERNAME',
@@ -89,7 +120,7 @@ MY_PROVIDER_TOKEN=
   });
 
   describe('when there is a previous existing .env', () => {
-    it('creates valid .env when no parameters or security schemes are given', () => {
+    it('creates valid .env when no token, no parameters or security schemes are given', () => {
       const result = createNewDotenv({
         previousDotenv: EXISTING_DOTENV,
         providerName: PROVIDER_NAME,
@@ -109,7 +140,8 @@ MY_PROVIDER_TOKEN=
       });
 
       expect(result).toStrictEqual({
-        content: `# Deployment zone
+        content: `SUPERFACE_ONESDK_TOKEN=sfs_b31314b7fc8...8ec1930e
+# Deployment zone
 # for AWS
 MY_PROVIDER_PARAM_TWO=us-west-1
 MY_PROVIDER_TOKEN=
@@ -130,7 +162,8 @@ MY_PROVIDER_PARAM_ONE=
       });
 
       expect(result).toStrictEqual({
-        content: `# Deployment zone
+        content: `SUPERFACE_ONESDK_TOKEN=sfs_b31314b7fc8...8ec1930e
+# Deployment zone
 # for AWS
 MY_PROVIDER_PARAM_TWO=us-west-1
 MY_PROVIDER_TOKEN=

--- a/src/logic/application-code/dotenv/dotenv.test.ts
+++ b/src/logic/application-code/dotenv/dotenv.test.ts
@@ -52,7 +52,7 @@ SUPERFACE_ONESDK_TOKEN=
       });
 
       expect(result).toStrictEqual({
-        content: `# OneSDK token lets your monitor your usage out-of-the-box at https://superface.ai/app
+        content: `# OneSDK token lets you monitor your usage out-of-the-box at https://superface.ai/app
 SUPERFACE_ONESDK_TOKEN=sfs_b31314b7fc8...8ec1930e
 `,
         addedEnvVariables: ['SUPERFACE_ONESDK_TOKEN'],
@@ -67,7 +67,7 @@ SUPERFACE_ONESDK_TOKEN=sfs_b31314b7fc8...8ec1930e
       });
 
       expect(result).toStrictEqual({
-        content: `# OneSDK token lets your monitor your usage out-of-the-box at https://superface.ai/app
+        content: `# OneSDK token lets you monitor your usage out-of-the-box at https://superface.ai/app
 SUPERFACE_ONESDK_TOKEN=sfs_b31314b7fc8...8ec1930e
 
 # Parameter description
@@ -94,7 +94,7 @@ MY_PROVIDER_PARAM_TWO=us-west-1
       });
 
       expect(result).toStrictEqual({
-        content: `# OneSDK token lets your monitor your usage out-of-the-box at https://superface.ai/app
+        content: `# OneSDK token lets you monitor your usage out-of-the-box at https://superface.ai/app
 SUPERFACE_ONESDK_TOKEN=sfs_b31314b7fc8...8ec1930e
 
 # Parameter description

--- a/src/logic/application-code/dotenv/dotenv.ts
+++ b/src/logic/application-code/dotenv/dotenv.ts
@@ -4,6 +4,12 @@ import {
   prepareSecurityValues,
 } from '@superfaceai/ast';
 
+import {
+  ONESDK_TOKEN_COMMENT,
+  ONESDK_TOKEN_ENV,
+  ONESDK_TOKEN_UNAVAILABLE_COMMENT,
+} from './onesdk-token';
+
 export type NewDotenv = {
   content: string;
   addedEnvVariables: string[];
@@ -20,25 +26,40 @@ export function createNewDotenv({
   providerName,
   parameters,
   security,
+  token,
 }: {
   previousDotenv?: string;
   providerName: string;
   parameters?: IntegrationParameter[];
   security?: SecurityScheme[];
+  token?: string | null;
 }): NewDotenv {
   const previousContent = previousDotenv ?? '';
 
   const parameterEnvs = getParameterEnvs(providerName, parameters);
   const securityEnvs = getSecurityEnvs(providerName, security);
-  const allProviderEnvVariables = [...parameterEnvs, ...securityEnvs];
+  const tokenEnv = makeTokenEnv(token);
+
+  const allEnvVariables = [tokenEnv, ...parameterEnvs, ...securityEnvs];
 
   const newEnvsOnly = makeFilterForNewEnvs(previousContent);
 
-  const newEnvVariables = allProviderEnvVariables.filter(newEnvsOnly);
+  const newEnvVariables = allEnvVariables.filter(newEnvsOnly);
 
   return {
     content: serializeContent(previousContent, newEnvVariables),
     addedEnvVariables: newEnvVariables.map(e => e.name),
+  };
+}
+
+function makeTokenEnv(token?: string | null): EnvVar {
+  return {
+    name: ONESDK_TOKEN_ENV,
+    value: token ?? undefined,
+    comment:
+      token !== undefined && token !== null
+        ? ONESDK_TOKEN_COMMENT
+        : ONESDK_TOKEN_UNAVAILABLE_COMMENT,
   };
 }
 

--- a/src/logic/application-code/dotenv/index.ts
+++ b/src/logic/application-code/dotenv/index.ts
@@ -1,1 +1,2 @@
-export * from './dotenv'
+export * from './dotenv';
+export * from './onesdk-token';

--- a/src/logic/application-code/dotenv/onesdk-token.ts
+++ b/src/logic/application-code/dotenv/onesdk-token.ts
@@ -1,0 +1,3 @@
+export const ONESDK_TOKEN_ENV = 'SUPERFACE_ONESDK_TOKEN';
+export const ONESDK_TOKEN_COMMENT = 'OneSDK token lets your monitor your usage out-of-the-box at https://superface.ai/app'
+export const ONESDK_TOKEN_UNAVAILABLE_COMMENT = 'Set your OneSDK token to monitor your usage out-of-the-box. Get yours at https://superface.ai/app'

--- a/src/logic/application-code/dotenv/onesdk-token.ts
+++ b/src/logic/application-code/dotenv/onesdk-token.ts
@@ -1,3 +1,3 @@
 export const ONESDK_TOKEN_ENV = 'SUPERFACE_ONESDK_TOKEN';
-export const ONESDK_TOKEN_COMMENT = 'OneSDK token lets your monitor your usage out-of-the-box at https://superface.ai/app'
+export const ONESDK_TOKEN_COMMENT = 'OneSDK token lets you monitor your usage out-of-the-box at https://superface.ai/app'
 export const ONESDK_TOKEN_UNAVAILABLE_COMMENT = 'Set your OneSDK token to monitor your usage out-of-the-box. Get yours at https://superface.ai/app'

--- a/src/logic/application-code/js/application-code.test.ts
+++ b/src/logic/application-code/js/application-code.test.ts
@@ -35,8 +35,8 @@ import { OneClient, PerformError, UnexpectedError } from '@superfaceai/one-sdk/n
 config();
 
 const client = new OneClient({
-  // Optionally you can use your OneSDK token to monitor your usage. Get one at https://superface.ai/app
-  // token:
+  // OneSDK token lets your monitor your usage out-of-the-box at https://superface.ai/app
+  token: process.env.SUPERFACE_ONESDK_TOKEN,
   // Specify path to assets folder
   assetsPath: '${buildSuperfaceDirPath()}'
 });

--- a/src/logic/application-code/js/application-code.test.ts
+++ b/src/logic/application-code/js/application-code.test.ts
@@ -35,7 +35,7 @@ import { OneClient, PerformError, UnexpectedError } from '@superfaceai/one-sdk/n
 config();
 
 const client = new OneClient({
-  // OneSDK token lets your monitor your usage out-of-the-box at https://superface.ai/app
+  // OneSDK token lets you monitor your usage out-of-the-box at https://superface.ai/app
   token: process.env.SUPERFACE_ONESDK_TOKEN,
   // Specify path to assets folder
   assetsPath: '${buildSuperfaceDirPath()}'

--- a/src/logic/application-code/js/application-code.ts
+++ b/src/logic/application-code/js/application-code.ts
@@ -3,6 +3,7 @@ import type { IntegrationParameter, SecurityScheme } from '@superfaceai/ast';
 import { buildSuperfaceDirPath } from '../../../common/file-structure';
 import { ProfileId } from '../../../common/profile';
 import type { ApplicationCodeWriter } from '../application-code';
+import { ONESDK_TOKEN_COMMENT, ONESDK_TOKEN_ENV } from '../dotenv';
 import { prepareParameters } from './parameters';
 import { prepareSecurity } from './security';
 
@@ -40,8 +41,8 @@ import { OneClient, PerformError, UnexpectedError } from '${pathToSdk}';
 config();
 
 const client = new OneClient({
-  // Optionally you can use your OneSDK token to monitor your usage. Get one at https://superface.ai/app
-  // token:
+  // ${ONESDK_TOKEN_COMMENT}
+  token: process.env.${ONESDK_TOKEN_ENV},
   // Specify path to assets folder
   assetsPath: '${buildSuperfaceDirPath()}'
 });

--- a/src/logic/application-code/python/application-code.test.ts
+++ b/src/logic/application-code/python/application-code.test.ts
@@ -36,7 +36,7 @@ load_dotenv()
 
 client = OneClient(
   # OneSDK token lets you monitor your usage out-of-the-box at https://superface.ai/app
-  token = os.getenv("SUPERFACE_ONESDK_TOKEN")
+  token = os.getenv("SUPERFACE_ONESDK_TOKEN"),
   # Specify path to assets folder
   assets_path = "${buildSuperfaceDirPath()}"
 )

--- a/src/logic/application-code/python/application-code.test.ts
+++ b/src/logic/application-code/python/application-code.test.ts
@@ -1,6 +1,5 @@
 import { MockLogger } from '../../../common';
 import { buildSuperfaceDirPath } from '../../../common/file-structure';
-import { ONESDK_TOKEN_COMMENT, ONESDK_TOKEN_ENV } from '../dotenv';
 import { pythonApplicationCode } from './application-code';
 
 describe('pythonApplicationCode', () => {
@@ -36,8 +35,8 @@ from one_sdk import OneClient, PerformError, UnexpectedError
 load_dotenv()
 
 client = OneClient(
-  # ${ONESDK_TOKEN_COMMENT}
-  token = os.getenv("${ONESDK_TOKEN_ENV}")
+  # OneSDK token lets your monitor your usage out-of-the-box at https://superface.ai/app
+  token = os.getenv("SUPERFACE_ONESDK_TOKEN")
   # Specify path to assets folder
   assets_path = "${buildSuperfaceDirPath()}"
 )

--- a/src/logic/application-code/python/application-code.test.ts
+++ b/src/logic/application-code/python/application-code.test.ts
@@ -1,5 +1,6 @@
 import { MockLogger } from '../../../common';
 import { buildSuperfaceDirPath } from '../../../common/file-structure';
+import { ONESDK_TOKEN_COMMENT, ONESDK_TOKEN_ENV } from '../dotenv';
 import { pythonApplicationCode } from './application-code';
 
 describe('pythonApplicationCode', () => {
@@ -35,8 +36,8 @@ from one_sdk import OneClient, PerformError, UnexpectedError
 load_dotenv()
 
 client = OneClient(
-  # Optionally you can use your OneSDK token to monitor your usage. Get one at https://superface.ai/app
-  # token =
+  # ${ONESDK_TOKEN_COMMENT}
+  token = os.getenv("${ONESDK_TOKEN_ENV}")
   # Specify path to assets folder
   assets_path = "${buildSuperfaceDirPath()}"
 )

--- a/src/logic/application-code/python/application-code.test.ts
+++ b/src/logic/application-code/python/application-code.test.ts
@@ -35,7 +35,7 @@ from one_sdk import OneClient, PerformError, UnexpectedError
 load_dotenv()
 
 client = OneClient(
-  # OneSDK token lets your monitor your usage out-of-the-box at https://superface.ai/app
+  # OneSDK token lets you monitor your usage out-of-the-box at https://superface.ai/app
   token = os.getenv("SUPERFACE_ONESDK_TOKEN")
   # Specify path to assets folder
   assets_path = "${buildSuperfaceDirPath()}"

--- a/src/logic/application-code/python/application-code.ts
+++ b/src/logic/application-code/python/application-code.ts
@@ -3,6 +3,7 @@ import type { IntegrationParameter, SecurityScheme } from '@superfaceai/ast';
 import { buildSuperfaceDirPath } from '../../../common/file-structure';
 import { ProfileId } from '../../../common/profile';
 import type { ApplicationCodeWriter } from '../application-code';
+import { ONESDK_TOKEN_COMMENT, ONESDK_TOKEN_ENV } from '../dotenv';
 import { prepareParameters } from './parameters';
 import { prepareSecurity } from './security';
 
@@ -37,8 +38,8 @@ from one_sdk import OneClient, PerformError, UnexpectedError
 load_dotenv()
 
 client = OneClient(
-  # Optionally you can use your OneSDK token to monitor your usage. Get one at https://superface.ai/app
-  # token =
+  # ${ONESDK_TOKEN_COMMENT}
+  token = os.getenv("${ONESDK_TOKEN_ENV}")
   # Specify path to assets folder
   assets_path = "${buildSuperfaceDirPath()}"
 )

--- a/src/logic/application-code/python/application-code.ts
+++ b/src/logic/application-code/python/application-code.ts
@@ -39,7 +39,7 @@ load_dotenv()
 
 client = OneClient(
   # ${ONESDK_TOKEN_COMMENT}
-  token = os.getenv("${ONESDK_TOKEN_ENV}")
+  token = os.getenv("${ONESDK_TOKEN_ENV}"),
   # Specify path to assets folder
   assets_path = "${buildSuperfaceDirPath()}"
 )


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR adds automatic pre-fill of OneSDK token when the boilerplate code is generated in `map` command.

You can go through commit by commit.

Tasks:
- [x] add utility for fetching OneSDK token
- [x] update `dotenv` utility to add the token by default to `.env` file
- [x] update JS boilerplate code to use the token from `.env`
- [x] update Python boilerplate code to use the token from `.env`
- [x] orchestrate the token fetcher and other parts in `map` command

## Motivation and Context
Having the token set by default enables our users to see their usage in the application dashboard.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
