### PR TITLE
chore: Remove userAgent extension in init hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,9 +74,6 @@
   "oclif": {
     "commands": "dist/commands",
     "bin": "superface",
-    "hooks": {
-      "init": "dist/hooks/init"
-    },
     "plugins": [
       "@oclif/plugin-warn-if-update-available"
     ],

--- a/src/hooks/init.ts
+++ b/src/hooks/init.ts
@@ -1,7 +1,0 @@
-import type { Hook } from '@oclif/config';
-import { VERSION as SDK_VERSION } from '@superfaceai/one-sdk';
-import { VERSION as PARSER_VERSION } from '@superfaceai/parser';
-
-export const hook: Hook<'init'> = async function (_options) {
-  this.config.userAgent += ` (with @superfaceai/one-sdk@${SDK_VERSION}, @superfaceai/parser@${PARSER_VERSION})`;
-};


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
Removing extension of userAgent (version string) with OneSDK and Parser dependencies version.

```
@superfaceai/cli/4.0.0-beta.12 darwin-arm64 node-v20.4.0 (with @superfaceai/one-sdk@2.4.2, @superfaceai/parser@2.1.0)
```

is now

```
@superfaceai/cli/4.0.0-beta.12 darwin-arm64 node-v20.4.0
```

## Motivation and Context
Having the OneSDK and Parser dependencies version printed out after `--version` is confusing to the users of the upcoming CLI. Those dependencies are there for the older commands, most likely to be removed soon.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
