### PR TITLE
chore(map): Guide for `execute` respects selected language

### DIFF
--- a/src/commands/execute.ts
+++ b/src/commands/execute.ts
@@ -37,13 +37,12 @@ export default class Execute extends Command {
       required: true,
     },
     {
-      // TODO: add language support
       name: 'language',
       description: 'Language which will use generated code. Default is `js`.',
       required: false,
       default: 'js',
       options: Object.values(SupportedLanguages),
-      // Hidden because we support only js for now
+      // Hidden until we figure better language select DX
       hidden: true,
     },
   ];


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR fixes example of `superface execute` command that is printed as a guide after `map` is done so that it respects the selected language.

**When language for `map` was NOT explicitly selected**
- `superface map <provider> <profileId>`, the user gets `superface execute <provider> <profileId>` 

**When language for `map` was explicitly selected**
- `superface map <provider> <profileId> python`, the user gets `superface execute <provider> <profileId> python` 
- `superface map <provider> <profileId> js`, the user gets `superface execute <provider> <profileId> js` 

**This doesn't touch the actual language switching logic, just CLI output for better DX**

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
