### PR TITLE
fix: `.env` doesn't contain duplicate variables

### DIFF
--- a/src/logic/application-code/dotenv/dotenv.test.ts
+++ b/src/logic/application-code/dotenv/dotenv.test.ts
@@ -33,8 +33,8 @@ MY_PROVIDER_TOKEN=
 `;
 
 describe('createNewDotenv', () => {
-  describe('when there is no previous .env', () => {
-    it('creates valid .env when no token, no parameters or security schemes are given', () => {
+  describe('OneSDK token', () => {
+    it('when no token is given, adds empty token env', () => {
       const result = createNewDotenv({ providerName: PROVIDER_NAME });
 
       expect(result).toStrictEqual({
@@ -45,7 +45,23 @@ SUPERFACE_ONESDK_TOKEN=
       });
     });
 
-    it('creates valid .env when valid token but no parameters or security schemes are given', () => {
+    it('when a token is given, adds pre-filled token env', () => {
+      const result = createNewDotenv({
+        providerName: PROVIDER_NAME,
+        token: TOKEN,
+      });
+
+      expect(result).toStrictEqual({
+        content: `# The token for monitoring your Comlinks at https://superface.ai
+SUPERFACE_ONESDK_TOKEN=sfs_b31314b7fc8...8ec1930e
+`,
+        newEmptyEnvVariables: [],
+      });
+    });
+  });
+
+  describe('when there is no previous .env', () => {
+    it('creates valid .env when no parameters or security schemes are given', () => {
       const result = createNewDotenv({
         providerName: PROVIDER_NAME,
         token: TOKEN,

--- a/src/logic/application-code/dotenv/dotenv.test.ts
+++ b/src/logic/application-code/dotenv/dotenv.test.ts
@@ -33,6 +33,26 @@ MY_PROVIDER_TOKEN=
 `;
 
 describe('createNewDotenv', () => {
+  it('when duplicate parameters or security schemes are given, adds the env only once', () => {
+    const result = createNewDotenv({
+      providerName: PROVIDER_NAME,
+      parameters: [PARAMETER, PARAMETER, PARAMETER],
+      security: [BEARER_AUTH,BEARER_AUTH,BEARER_AUTH],
+      token: TOKEN,
+    });
+
+    expect(result).toStrictEqual({
+      content: `# The token for monitoring your Comlinks at https://superface.ai
+SUPERFACE_ONESDK_TOKEN=sfs_b31314b7fc8...8ec1930e
+
+# Parameter description
+MY_PROVIDER_PARAM_ONE=
+MY_PROVIDER_TOKEN=
+`,
+      newEmptyEnvVariables: ['MY_PROVIDER_PARAM_ONE', 'MY_PROVIDER_TOKEN'],
+    });
+  });
+
   describe('OneSDK token', () => {
     it('when no token is given, adds empty token env', () => {
       const result = createNewDotenv({ providerName: PROVIDER_NAME });

--- a/src/logic/application-code/dotenv/dotenv.ts
+++ b/src/logic/application-code/dotenv/dotenv.ts
@@ -40,11 +40,11 @@ export function createNewDotenv({
   const securityEnvs = getSecurityEnvs(providerName, security);
   const tokenEnv = makeTokenEnv(token);
 
-  const allEnvVariables = [tokenEnv, ...parameterEnvs, ...securityEnvs];
-
   const newEnvsOnly = makeFilterForNewEnvs(previousContent);
 
-  const newEnvVariables = allEnvVariables.filter(newEnvsOnly);
+  const newEnvVariables = [tokenEnv, ...parameterEnvs, ...securityEnvs]
+    .filter(uniqueEnvsOnly)
+    .filter(newEnvsOnly);
 
   return {
     content: serializeContent(previousContent, newEnvVariables),
@@ -63,6 +63,10 @@ function makeTokenEnv(token?: string | null): EnvVar {
         ? ONESDK_TOKEN_COMMENT
         : ONESDK_TOKEN_UNAVAILABLE_COMMENT,
   };
+}
+
+function uniqueEnvsOnly(env: EnvVar, ix: number, arr: EnvVar[]): boolean {
+  return arr.findIndex(e => e.name === env.name) === ix;
 }
 
 function makeFilterForNewEnvs(content: string): (e: EnvVar) => boolean {


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
Fixing `dotenv` utility so that it doesn't create duplicate env variables in `.env`.

The first commit is just refactoring of the test code. Easier to review just the second commit.

## Motivation and Context
When provider has >1 security schemes of same type (or same-named parameters but that shouldn't happen), env vars are added to `.env` multiple times.

```json
{
  "name": "hubspot",
  "defaultService": "default",
  "parameters": [],
  "services": [
    {
      "baseUrl": "https://api.hubapi.com/",
      "id": "default"
    }
  ],
  "securitySchemes": [
    {
      "type": "apiKey",
      "name": "private-app-legacy",
      "in": "header",
      "id": "private_apps_legacy"
    },
    {
      "type": "apiKey",
      "name": "private-app",
      "in": "header",
      "id": "private_apps"
    }
  ]
}
```

creates the following .env

```env
HUBSPOT_API_KEY=
HUBSPOT_API_KEY=
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
