### PR TITLE
docs: Replace Discord refs w/ GH Discussions, rename CONTRIBUTION_GUIDE

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@
 <!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 <!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
 - [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
-- [ ] I have read the **CONTRIBUTION_GUIDE** document.
+- [ ] I have read the **CONTRIBUTING** document.
 - [ ] I haven't repeated the code. (DRY)
 - [ ] I have added tests to cover my changes.
 - [ ] All new and existing tests passed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,9 @@ We are glad that you are interested in Superface in the way of contributing. We 
 
 ## Help the community
 
-1) Report an Error or a Bug
-2) Contribute to the Documentation
-3) Provide Support on Issues
+1. Report an Error or a Bug
+2. Contribute to the Documentation
+3. Provide Support on Issues
 
 ## Need help?
 
@@ -22,7 +22,7 @@ If you have any question about this project (for example, how to use it) or if y
 
 Follow these steps:
 
-1. **Fork & Clone** the repository  
+1. **Fork & Clone** the repository
 2. **Setup** the Superface CLI
    - Install packages with `yarn install` or `npm install`
    - Build with `yarn build` or `npm run build`
@@ -30,7 +30,7 @@ Follow these steps:
    - Lint code with `yarn lint:fix` or `npm run lint:fix`
 3. **Update** [CHANGELOG](CHANGELOG.md). See https://keepachangelog.com/en/1.0.0/
 4. **Commit** changes to your own branch by convention. See https://www.conventionalcommits.org/en/v1.0.0/
-5. **Push** your work back up to your fork  
+5. **Push** your work back up to your fork
 6. Submit a **Pull Request** so that we can review your changes
 
 **NOTE: Be sure to merge the latest from "upstream" before making a pull request.**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[Website](https://superface.ai) | [Get Started](https://superface.ai/docs/introduction/getting-started) | [Documentation](https://superface.ai/docs) | [Discord](https://sfc.is/discord) | [Twitter](https://twitter.com/superfaceai) | [Support](https://superface.ai/support)
+[Website](https://superface.ai) | [Get Started](https://superface.ai/docs/introduction/getting-started) | [Documentation](https://superface.ai/docs) | [GitHub Discussions](https://sfc.is/discussions) | [Twitter](https://twitter.com/superfaceai) | [Support](https://superface.ai/support)
 
-<img src="https://github.com/superfaceai/cli/blob/main/docs/LogoGreen.png" alt="superface logo" width="100" height="100">
+<img src="https://github.com/superfaceai/cli/blob/main/docs/LogoGreen.png" alt="Superface" width="100" height="100">
 
 # Superface CLI
 
@@ -298,7 +298,7 @@ To install a local artifact globally, symlink the binary (`ln -s bin/superface <
 
 **Please open an issue first if you want to make larger changes**
 
-Feel free to contribute! Please follow the [Contribution Guide](CONTRIBUTION_GUIDE.md).
+Feel free to contribute! Please follow the [Contribution Guide](CONTRIBUTING.md).
 
 Licenses of node_modules are checked during CI/CD for every commit. Only the following licenses are allowed:
 
@@ -318,4 +318,5 @@ Note: If editing the README, please conform to the [standard-readme](https://git
 ## License
 
 The Superface CLI is licensed under the [MIT](LICENSE).
+
 © 2023 Superface


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
- Link to GH Discussions instead of Discord
- Rename CONTRIBUTION_GUIDE.md to CONTRIBUTING.md and related references, since the latter name is standardized.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTION_GUIDE** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
