### PR TITLE
fix: path escaping

### DIFF
--- a/src/common/file-structure.ts
+++ b/src/common/file-structure.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'path';
+import { basename, join, resolve } from 'path';
 
 import { SupportedLanguages } from '../logic/application-code/application-code';
 
@@ -11,13 +11,12 @@ const PROVIDER_EXTENSION = '.provider.json';
 const MAP_EXTENSION = '.map.js';
 
 export function isInsideSuperfaceDir(): boolean {
-  return process.cwd().endsWith('/' + DEFAULT_SUPERFACE_DIR);
+  return basename(process.cwd()) === DEFAULT_SUPERFACE_DIR;
 }
 
 export function buildSuperfaceDirPath(): string {
   // If user is in superface dir, use it
-  if (process.cwd().endsWith('/' + DEFAULT_SUPERFACE_DIR))
-    return resolve(process.cwd());
+  if (isInsideSuperfaceDir()) return resolve(process.cwd());
 
   return join(resolve(process.cwd()), DEFAULT_SUPERFACE_DIR);
 }

--- a/src/logic/application-code/js/application-code.test.ts
+++ b/src/logic/application-code/js/application-code.test.ts
@@ -2,8 +2,17 @@ import { MockLogger } from '../../../common';
 import { buildSuperfaceDirPath } from '../../../common/file-structure';
 import { jsApplicationCode } from './application-code';
 
+jest.mock('../../../common/file-structure');
+
 describe('jsApplicationCode', () => {
-  it('should return correct application code', async () => {
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should return correct application code for unix', async () => {
+    jest
+      .mocked(buildSuperfaceDirPath)
+      .mockReturnValue('/Users/test/cli-test/superface');
     const scope = 'test-scope';
     const name = 'test-name';
     const provider = 'test-provider';
@@ -38,7 +47,81 @@ const client = new OneClient({
   // The token for monitoring your Comlinks at https://superface.ai
   token: process.env.SUPERFACE_ONESDK_TOKEN,
   // Path to Comlinks within your project
-  assetsPath: '${buildSuperfaceDirPath()}'
+  assetsPath: '/Users/test/cli-test/superface'
+});
+
+// Load Comlink profile and use case
+const profile = await client.getProfile('${scope}/${name}');
+const useCase = profile.getUseCase('${useCaseName}');
+
+try {
+  // Execute use case
+  const result = await useCase.perform(
+    // Use case input
+    {},
+    {
+      provider: '${provider}',
+      parameters: {},
+      // Security values for provider
+      security: {}
+    }
+  );
+
+  console.log("RESULT:", JSON.stringify(result, null, 2));
+} catch (e) {
+  if (e instanceof PerformError) {
+    console.log('ERROR RESULT:', e.errorResult);
+  } else if (e instanceof UnexpectedError) {
+    console.error('ERROR:', e);
+  } else {
+    throw e;
+  }
+}
+`,
+      requiredParameters: [],
+      requiredSecurity: [],
+    });
+  });
+
+  it('should return correct application code for windows', async () => {
+    jest
+      .mocked(buildSuperfaceDirPath)
+      .mockReturnValue('C:\\Users\\my\\cli-test\\superface');
+    const scope = 'test-scope';
+    const name = 'test-name';
+    const provider = 'test-provider';
+    const useCaseName = 'test-use-case-name';
+
+    const logger = new MockLogger();
+
+    const result = jsApplicationCode(
+      {
+        profile: {
+          scope,
+          name,
+        },
+        useCaseName,
+        provider,
+        input: '{}',
+        parameters: [],
+        security: [],
+      },
+      { logger }
+    );
+
+    expect(result).toEqual({
+      code: `import { config } from 'dotenv';
+// Load OneClient from SDK
+import { OneClient, PerformError, UnexpectedError } from '@superfaceai/one-sdk/node/index.js';
+
+// Load environment variables from .env file
+config();
+
+const client = new OneClient({
+  // The token for monitoring your Comlinks at https://superface.ai
+  token: process.env.SUPERFACE_ONESDK_TOKEN,
+  // Path to Comlinks within your project
+  assetsPath: 'C:\\\\Users\\\\my\\\\cli-test\\\\superface'
 });
 
 // Load Comlink profile and use case

--- a/src/logic/application-code/js/application-code.ts
+++ b/src/logic/application-code/js/application-code.ts
@@ -44,7 +44,7 @@ const client = new OneClient({
   // ${ONESDK_TOKEN_COMMENT}
   token: process.env.${ONESDK_TOKEN_ENV},
   // Path to Comlinks within your project
-  assetsPath: '${buildSuperfaceDirPath()}'
+  assetsPath: '${escapeAssetspath(buildSuperfaceDirPath())}'
 });
 
 // Load Comlink profile and use case
@@ -82,3 +82,8 @@ try {
     requiredSecurity: preparedSecurity.required,
   };
 };
+
+function escapeAssetspath(path: string): string {
+  // Escape backslashes for Windows
+  return path.replace(/\\/g, '\\\\');
+}


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR fixes two issues with path when using CLI on Windows:
Invalid use of `/` in check was replaced with `path.basename`
Windows \ are now escaped in `assetsPath` in .mjs file template

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [x] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [x] I have read the **CONTRIBUTING** document.
- [x] I haven't repeated the code. (DRY)
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
