### PR TITLE
chore: print source in error

### DIFF
--- a/src/commands/prepare.test.ts
+++ b/src/commands/prepare.test.ts
@@ -131,12 +131,16 @@ describe('prepare CLI command', () => {
       jest.mocked(readFile).mockResolvedValueOnce(fileContent);
       jest.mocked(prepareProviderJson).mockResolvedValueOnce(providerJson);
 
-      await expect(instance.execute({
-        logger,
-        userError,
-        flags: {},
-        args: { urlOrPath: 'path/to/FILE.docs.2!87.yaml' },
-      })).rejects.toThrow(`Provider name inferred from file name is not valid. Please provide provider name explicitly as second argument.`);
+      await expect(
+        instance.execute({
+          logger,
+          userError,
+          flags: {},
+          args: { urlOrPath: 'path/to/FILE.docs.2!87.yaml' },
+        })
+      ).rejects.toThrow(
+        `Provider name inferred from file name is not valid. Please provide provider name explicitly as second argument.`
+      );
     });
 
     it('prepares provider json from url', async () => {

--- a/src/logic/new.ts
+++ b/src/logic/new.ts
@@ -28,7 +28,7 @@ function assertProfileResponse(
   ) {
     const tmp = input as { id: string; profile: { source?: string } };
 
-    if (typeof tmp.profile.source !== 'string') {
+    if (typeof tmp.profile?.source !== 'string') {
       throw userError(
         `Unexpected response received - missing profile source: ${JSON.stringify(
           tmp,
@@ -43,11 +43,9 @@ function assertProfileResponse(
       parseProfile(new Source(tmp.profile.source));
     } catch (e) {
       throw userError(
-        `Unexpected response received - unable to parse profile source: ${JSON.stringify(
-          e,
-          null,
-          2
-        )}`,
+        `Unexpected response received - unable to parse profile source: ${
+          tmp.profile.source
+        }, error: ${JSON.stringify(e, null, 2)}`,
         1
       );
     }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description

This PR adds printing out of profile source in cases when CLI is not able to parse it, this allows for easier debug.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
