### PR TITLE
feat: verbose flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,17 +184,18 @@ Learns API from the documentation and prepares the API metadata.
 
 ```
 USAGE
-  $ superface prepare URLORPATH [NAME] [-q] [--noColor] [--noEmoji] [-h]
+  $ superface prepare URLORPATH [NAME] [-q] [--noColor] [--noEmoji] [-h] [-v]
 
 ARGUMENTS
   URLORPATH  URL or path to the API documentation.
   NAME       API name. If not provided, it will be inferred from URL or file name.
 
 FLAGS
-  -h, --help   show CLI help
-  -q, --quiet  When set to true, disables the shell echo output of action.
-  --noColor    When set to true, disables all colored output.
-  --noEmoji    When set to true, disables displaying emoji in output.
+  -h, --help     show CLI help
+  -q, --quiet    When set to true, disables the shell echo output of action.
+  -v, --verbose  When set to true command will print the indexed documentation overview. This is useful for debugging.
+  --noColor      When set to true, disables all colored output.
+  --noEmoji      When set to true, disables displaying emoji in output.
 
 DESCRIPTION
   Learns API from the documentation and prepares the API metadata.
@@ -241,6 +242,8 @@ EXAMPLES
   $ superface prepare path/to/openapi.json
 
   $ superface prepare https://workable.readme.io/reference/stages workable
+
+  $ superface prepare https://workable.readme.io/reference/stages workable --verbose
 ```
 
 _See code: [dist/commands/prepare.ts](https://github.com/superfaceai/cli/tree/main/src/commands/prepare.ts)_

--- a/src/commands/prepare.test.ts
+++ b/src/commands/prepare.test.ts
@@ -109,7 +109,9 @@ describe('prepare CLI command', () => {
       const providerJson = mockProviderJson();
       jest.mocked(exists).mockResolvedValueOnce(true);
       jest.mocked(readFile).mockResolvedValueOnce('file content');
-      jest.mocked(prepareProviderJson).mockResolvedValueOnce(providerJson);
+      jest
+        .mocked(prepareProviderJson)
+        .mockResolvedValueOnce({ definition: providerJson });
       jest.mocked(exists).mockResolvedValueOnce(true);
       await expect(
         instance.execute({
@@ -129,7 +131,9 @@ describe('prepare CLI command', () => {
         .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(false);
       jest.mocked(readFile).mockResolvedValueOnce(fileContent);
-      jest.mocked(prepareProviderJson).mockResolvedValueOnce(providerJson);
+      jest
+        .mocked(prepareProviderJson)
+        .mockResolvedValueOnce({ definition: providerJson });
 
       await expect(
         instance.execute({
@@ -146,7 +150,9 @@ describe('prepare CLI command', () => {
     it('prepares provider json from url', async () => {
       const providerJson = mockProviderJson();
       jest.mocked(exists).mockResolvedValue(false);
-      jest.mocked(prepareProviderJson).mockResolvedValueOnce(providerJson);
+      jest
+        .mocked(prepareProviderJson)
+        .mockResolvedValueOnce({ definition: providerJson });
       const url = 'https://geocode.search.hereapi.com/oas.yaml';
 
       await instance.execute({
@@ -175,7 +181,9 @@ describe('prepare CLI command', () => {
       const name = 'test';
       const providerJson = mockProviderJson({ name });
       jest.mocked(exists).mockResolvedValue(false);
-      jest.mocked(prepareProviderJson).mockResolvedValueOnce(providerJson);
+      jest
+        .mocked(prepareProviderJson)
+        .mockResolvedValueOnce({ definition: providerJson });
       const url = 'https://geocode.search.hereapi.com/oas.yaml';
 
       await instance.execute({
@@ -208,7 +216,9 @@ describe('prepare CLI command', () => {
         .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(false);
       jest.mocked(readFile).mockResolvedValueOnce(fileContent);
-      jest.mocked(prepareProviderJson).mockResolvedValueOnce(providerJson);
+      jest
+        .mocked(prepareProviderJson)
+        .mockResolvedValueOnce({ definition: providerJson });
 
       await instance.execute({
         logger,
@@ -241,7 +251,9 @@ describe('prepare CLI command', () => {
         .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(false);
       jest.mocked(readFile).mockResolvedValueOnce(fileContent);
-      jest.mocked(prepareProviderJson).mockResolvedValueOnce(providerJson);
+      jest
+        .mocked(prepareProviderJson)
+        .mockResolvedValueOnce({ definition: providerJson });
 
       await instance.execute({
         logger,

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -53,7 +53,7 @@ This command prepares a Provider JSON metadata definition that can be used to ge
     'superface prepare https://raw.githubusercontent.com/APIs-guru/openapi-directory/main/APIs/openai.com/1.2.0/openapi.yaml openai',
     'superface prepare path/to/openapi.json',
     'superface prepare https://workable.readme.io/reference/stages workable',
-    'superface prepare https://workable.readme.io/reference/stages workable --printDocs',
+    'superface prepare https://workable.readme.io/reference/stages workable --verbose',
   ];
 
   public static args = [
@@ -72,7 +72,8 @@ This command prepares a Provider JSON metadata definition that can be used to ge
 
   public static flags = {
     ...Command.flags,
-    printDocs: oclifFlags.boolean({
+    verbose: oclifFlags.boolean({
+      char: 'v',
       required: false,
       description:
         'When set to true command will print the indexed documentation overview. This is useful for debugging.',
@@ -123,7 +124,7 @@ This command prepares a Provider JSON metadata definition that can be used to ge
       {
         urlOrSource: resolved.source,
         name: resolved.name,
-        options: { quiet: flags.quiet, getDocs: flags.printDocs },
+        options: { quiet: flags.quiet, getDocs: flags.verbose },
       },
       { userError, ux }
     );

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -141,7 +141,7 @@ This command prepares a Provider JSON metadata definition that can be used to ge
     );
 
     const docs = providerJsonResult.docs
-      ? `\n{bold gray Idexed documentation:}\n${providerJsonResult.docs
+      ? `\n{bold gray Indexed documentation:}\n${providerJsonResult.docs
           .map(d => d.replace(/{/g, '\\{').replace(/}/g, '\\}'))
           .join('\n')}\n`
       : ``;

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -141,9 +141,9 @@ This command prepares a Provider JSON metadata definition that can be used to ge
     );
 
     const docs = providerJsonResult.docs
-      ? `\n{bold gray Indexed documentation:}\n${providerJsonResult.docs
+      ? `\n{bold Indexed documentation:}{grey \n${providerJsonResult.docs
           .map(d => d.replace(/{/g, '\\{').replace(/}/g, '\\}'))
-          .join('\n')}\n`
+          .join('\n')}\n}`
       : ``;
 
     const providerJson = providerJsonResult.definition;

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -130,8 +130,8 @@ This command prepares a Provider JSON metadata definition that can be used to ge
 
     const docs = providerJsonResult.docs
       ? `\n{bold gray Idexed documentation:}\n${providerJsonResult.docs
-        .map(d => d.replace(/{/g, '\\{').replace(/}/g, '\\}'))
-        .join('\n')}\n`
+          .map(d => d.replace(/{/g, '\\{').replace(/}/g, '\\}'))
+          .join('\n')}\n`
       : ``;
 
     const providerJson = providerJsonResult.definition;

--- a/src/logic/prepare.test.ts
+++ b/src/logic/prepare.test.ts
@@ -66,7 +66,10 @@ describe('prepareProviderJson', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined, pollingTimeoutSeconds: 123 }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://superface.ai/job/123', {

--- a/src/logic/prepare.test.ts
+++ b/src/logic/prepare.test.ts
@@ -118,7 +118,9 @@ describe('prepareProviderJson', () => {
       )
     ).resolves.toEqual({
       definition: mockProviderJson({ name: providerName }),
-      docs: ['test...', 'test...', '{}...', 'test...'],
+      docs: [
+        'test...\n==========\ntest...\n==========\n{}...\n==========\ntest...',
+      ],
     });
 
     expect(fetch).toHaveBeenNthCalledWith(1, '/authoring/providers', {

--- a/src/logic/prepare.ts
+++ b/src/logic/prepare.ts
@@ -13,6 +13,45 @@ type ProviderPreparationResponse = {
   docs_url: string;
 };
 
+type ProviderDocsResponse = {
+  data: {
+    source: string;
+    created_at: string;
+  }[];
+  url: string;
+};
+
+function assertProviderDocsResponse(
+  input: unknown,
+  { userError }: { userError: UserError }
+): asserts input is ProviderDocsResponse {
+  if (
+    typeof input === 'object' &&
+    input !== null &&
+    'data' in input &&
+    'url' in input
+  ) {
+    const tmp = input as {
+      data: {
+        source: string;
+        created_at: string;
+      }[];
+      url: string;
+    };
+
+    if (
+      typeof tmp.url === 'string' &&
+      Array.isArray(tmp.data) &&
+      tmp.data.every(item => typeof item.source === 'string') &&
+      tmp.data.every(item => typeof item.created_at === 'string')
+    ) {
+      return;
+    }
+  }
+
+  throw userError(`Unexpected response received`, 1);
+}
+
 function assertProviderResponse(
   input: unknown,
   { userError }: { userError: UserError }
@@ -53,10 +92,11 @@ export async function prepareProviderJson(
     name: string | undefined;
     options?: {
       quiet?: boolean;
+      getDocs?: boolean;
     };
   },
   { userError, ux }: { userError: UserError; ux: UX }
-): Promise<ProviderJson> {
+): Promise<{ definition: ProviderJson; docs?: string[] }> {
   const client = SuperfaceClient.getClient();
 
   const jobUrl = await startProviderPreparation(
@@ -69,13 +109,20 @@ export async function prepareProviderJson(
     { client, ux, userError }
   );
 
-  // TODO: use docs_url to keep track of docs
-  return (
-    await finishProviderPreparation(resultUrl, {
+  const providerResponse = await finishProviderPreparation(resultUrl, {
+    client,
+    userError,
+  });
+
+  let docs: string[] | undefined;
+  if (options?.getDocs === true) {
+    docs = await getIndexedDocs(providerResponse.docs_url, {
       client,
       userError,
-    })
-  ).definition;
+    });
+  }
+
+  return { definition: providerResponse.definition, docs };
 }
 
 async function startProviderPreparation(
@@ -145,4 +192,37 @@ async function finishProviderPreparation(
   assertProviderResponse(body, { userError });
 
   return body;
+}
+
+async function getIndexedDocs(
+  docsUrl: string,
+  { client, userError }: { client: ServiceClient; userError: UserError }
+): Promise<string[]> {
+  const resultResponse = await client.fetch(docsUrl, {
+    method: 'GET',
+    headers: {
+      accept: 'application/json',
+    },
+    // Url from server is complete, so we don't need to add baseUrl
+    baseUrl: '',
+  });
+
+  if (resultResponse.status !== 200) {
+    throw userError(
+      `Unexpected status code ${resultResponse.status} received`,
+      1
+    );
+  }
+
+  const body = (await resultResponse.json()) as unknown;
+
+  assertProviderDocsResponse(body, { userError });
+
+  return body.data.map(item =>
+    item.source
+      .split(/===+\n/)
+      .filter(Boolean)
+      .map(text => text.substring(0, 200).trim() + '...')
+      .join('\n==========\n')
+  );
 }

--- a/src/logic/prepare.ts
+++ b/src/logic/prepare.ts
@@ -229,7 +229,7 @@ async function getIndexedDocs(
     item.source
       .split(/===+\n/)
       .filter(Boolean)
-      .map(text => text.substring(0, 200).trim() + '...')
+      .map(text => text.substring(0, 1000).trim() + '...')
       .join('\n==========\n')
   );
 }


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR adds optional `printDocs` flag that prints overview of indexed documentation chunks. This can be useful for debugging.

Output looks like this:

![Snímek obrazovky 2023-09-21 v 12 14 43](https://github.com/superfaceai/cli/assets/21127441/f7093c6b-a516-4e7d-bf4d-9ff37ef32ba9)


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
