### PR TITLE
feat: poll url retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- added poll URL retries
+
 ### Fixed
 - Printing error message twice
 

--- a/src/common/polling.test.ts
+++ b/src/common/polling.test.ts
@@ -68,6 +68,61 @@ describe('polling', () => {
     });
   });
 
+  it('polls until job is done - uses retry', async () => {
+    const resultUrl = 'https://superface.ai/resource/1';
+
+    mockFetch
+      .mockResolvedValueOnce(new Error('1 call 1 error'))
+      .mockResolvedValueOnce(new Error('1 call 2 error'))
+      .mockResolvedValueOnce(
+        mockResponse(200, 'ok', undefined, {
+          status: 'Pending',
+          result_type: 'Provider',
+          events: [
+            { type: 'info', description: 'first', occuredAt: new Date() },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(new Error('2 call 1 error'))
+      .mockResolvedValueOnce(
+        mockResponse(200, 'ok', undefined, {
+          status: 'Pending',
+          result_type: 'Provider',
+          events: [
+            { type: 'info', description: 'second', occuredAt: new Date() },
+          ],
+        })
+      )
+      .mockResolvedValueOnce(new Error('3 call 1 error'))
+      .mockResolvedValueOnce(
+        mockResponse(200, 'ok', undefined, {
+          status: 'Success',
+          result_type: 'Provider',
+          result_url: resultUrl,
+        })
+      );
+
+    await expect(
+      pollUrl(
+        {
+          url: jobUrl,
+          options: { quiet: false },
+        },
+        { client, ux, userError }
+      )
+    ).resolves.toEqual(resultUrl);
+
+    expect(mockFetch).toHaveBeenCalledTimes(7);
+
+    expect(mockFetch).toHaveBeenCalledWith(jobUrl, {
+      method: 'GET',
+      baseUrl: '',
+      headers: {
+        accept: 'application/json',
+      },
+    });
+  });
+
   it('polls until job is cancelled', async () => {
     mockFetch
       .mockResolvedValueOnce(
@@ -202,9 +257,7 @@ describe('polling', () => {
   });
 
   it('throws when fetch returns unexpected status code', async () => {
-    mockFetch.mockResolvedValueOnce(
-      mockResponse(400, 'Bad Request', undefined)
-    );
+    mockFetch.mockResolvedValue(mockResponse(400, 'Bad Request', undefined));
 
     await expect(
       pollUrl(
@@ -216,9 +269,9 @@ describe('polling', () => {
         },
         { client, ux, userError }
       )
-    ).rejects.toThrow('Unexpected status code 400 received');
+    ).rejects.toThrow('Unexpected error: 400 Bad Request received');
 
-    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
 
     expect(mockFetch).toHaveBeenCalledWith(jobUrl, {
       method: 'GET',
@@ -230,7 +283,7 @@ describe('polling', () => {
   });
 
   it('throws when fetch returns unexpected body', async () => {
-    mockFetch.mockResolvedValueOnce(
+    mockFetch.mockResolvedValue(
       mockResponse(200, 'ok', undefined, { foo: 'bar' })
     );
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR adds retry of polling of job status. This helps with `SOCKET_CONNECTION_TIMEOUT` breaking long running authoring process. Default value is 3 retries.  

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
