### PR TITLE
Feat/poll timeout flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- flag to configure polling timeout 
 - added poll URL retries
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -128,8 +128,8 @@ ARGUMENTS
 FLAGS
   -h, --help             show CLI help
   -q, --quiet            When set to true, disables the shell echo output of action.
-  -t, --timeout=<value>  [default: 300] Opration timeout in seconds. If not provided, it will be set to 300 seconds.
-                         Usefull for large APIs.
+  -t, --timeout=<value>  [default: 300] Operation timeout in seconds. If not provided, it will be set to 300 seconds.
+                         Useful for large API documentations.
   --noColor              When set to true, disables all colored output.
   --noEmoji              When set to true, disables displaying emoji in output.
 

--- a/README.md
+++ b/README.md
@@ -162,8 +162,8 @@ ARGUMENTS
 FLAGS
   -h, --help             show CLI help
   -q, --quiet            When set to true, disables the shell echo output of action.
-  -t, --timeout=<value>  [default: 300] Opration timeout in seconds. If not provided, it will be set to 300 seconds.
-                         Usefull for large APIs.
+  -t, --timeout=<value>  [default: 300] Operation timeout in seconds. If not provided, it will be set to 300 seconds.
+                         Useful for large API documentations.
   --noColor              When set to true, disables all colored output.
   --noEmoji              When set to true, disables displaying emoji in output.
 
@@ -197,8 +197,8 @@ ARGUMENTS
 FLAGS
   -h, --help             show CLI help
   -q, --quiet            When set to true, disables the shell echo output of action.
-  -t, --timeout=<value>  [default: 300] Opration timeout in seconds. If not provided, it will be set to 300 seconds.
-                         Usefull for large APIs.
+  -t, --timeout=<value>  [default: 300] Operation timeout in seconds. If not provided, it will be set to 300 seconds.
+                         Useful for large API documentations.
   --noColor              When set to true, disables all colored output.
   --noEmoji              When set to true, disables displaying emoji in output.
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Creates a new (or updates an existing) Comlink Map that maps the use case to the
 
 ```
 USAGE
-  $ superface map PROVIDERNAME [PROFILEID] [LANGUAGE] [-q] [--noColor] [--noEmoji] [-h]
+  $ superface map PROVIDERNAME [PROFILEID] [LANGUAGE] [-q] [--noColor] [--noEmoji] [-h] [-t <value>]
 
 ARGUMENTS
   PROVIDERNAME  Name of provider.
@@ -126,10 +126,12 @@ ARGUMENTS
   LANGUAGE      (python|js) [default: js] Language of the generated application code. Default is `js`
 
 FLAGS
-  -h, --help   show CLI help
-  -q, --quiet  When set to true, disables the shell echo output of action.
-  --noColor    When set to true, disables all colored output.
-  --noEmoji    When set to true, disables displaying emoji in output.
+  -h, --help             show CLI help
+  -q, --quiet            When set to true, disables the shell echo output of action.
+  -t, --timeout=<value>  [default: 300] Opration timeout in seconds. If not provided, it will be set to 300 seconds.
+                         Usefull for large APIs.
+  --noColor              When set to true, disables all colored output.
+  --noEmoji              When set to true, disables displaying emoji in output.
 
 DESCRIPTION
   Creates a new (or updates an existing) Comlink Map that maps the use case to the selected API provider. After Map is
@@ -149,7 +151,7 @@ Creates new Comlink Profile for your use case based on the selected API. Comlink
 
 ```
 USAGE
-  $ superface new PROVIDERNAME PROMPT [PROFILEID] [-q] [--noColor] [--noEmoji] [-h]
+  $ superface new PROVIDERNAME PROMPT [PROFILEID] [-q] [--noColor] [--noEmoji] [-h] [-t <value>]
 
 ARGUMENTS
   PROVIDERNAME  URL or path to the API documentation.
@@ -158,10 +160,12 @@ ARGUMENTS
                 inferred from the prompt.
 
 FLAGS
-  -h, --help   show CLI help
-  -q, --quiet  When set to true, disables the shell echo output of action.
-  --noColor    When set to true, disables all colored output.
-  --noEmoji    When set to true, disables displaying emoji in output.
+  -h, --help             show CLI help
+  -q, --quiet            When set to true, disables the shell echo output of action.
+  -t, --timeout=<value>  [default: 300] Opration timeout in seconds. If not provided, it will be set to 300 seconds.
+                         Usefull for large APIs.
+  --noColor              When set to true, disables all colored output.
+  --noEmoji              When set to true, disables displaying emoji in output.
 
 DESCRIPTION
   Creates new Comlink Profile for your use case based on the selected API. Comlink Profile defines the interface of the
@@ -184,17 +188,19 @@ Learns API from the documentation and prepares the API metadata.
 
 ```
 USAGE
-  $ superface prepare URLORPATH [NAME] [-q] [--noColor] [--noEmoji] [-h]
+  $ superface prepare URLORPATH [NAME] [-q] [--noColor] [--noEmoji] [-h] [-t <value>]
 
 ARGUMENTS
   URLORPATH  URL or path to the API documentation.
   NAME       API name. If not provided, it will be inferred from URL or file name.
 
 FLAGS
-  -h, --help   show CLI help
-  -q, --quiet  When set to true, disables the shell echo output of action.
-  --noColor    When set to true, disables all colored output.
-  --noEmoji    When set to true, disables displaying emoji in output.
+  -h, --help             show CLI help
+  -q, --quiet            When set to true, disables the shell echo output of action.
+  -t, --timeout=<value>  [default: 300] Opration timeout in seconds. If not provided, it will be set to 300 seconds.
+                         Usefull for large APIs.
+  --noColor              When set to true, disables all colored output.
+  --noEmoji              When set to true, disables displaying emoji in output.
 
 DESCRIPTION
   Learns API from the documentation and prepares the API metadata.

--- a/src/commands/map.test.ts
+++ b/src/commands/map.test.ts
@@ -95,7 +95,7 @@ describe('MapCLI command', () => {
           instance.execute({
             logger,
             userError,
-            flags: {},
+            flags: { timeout: 123 },
             args: {
               providerName,
               profileId: profileName,
@@ -118,7 +118,7 @@ describe('MapCLI command', () => {
           instance.execute({
             logger,
             userError,
-            flags: {},
+            flags: { timeout: 123 },
             args: { profileId: profileName },
           })
         ).rejects.toThrow(
@@ -135,7 +135,7 @@ describe('MapCLI command', () => {
           instance.execute({
             logger,
             userError,
-            flags: {},
+            flags: { timeout: 123 },
             args: { providerName },
           })
         ).rejects.toThrow(
@@ -154,7 +154,7 @@ describe('MapCLI command', () => {
           instance.execute({
             logger,
             userError,
-            flags: {},
+            flags: { timeout: 123 },
             args: { providerName, profileId: '!_0%L' },
           })
         ).rejects.toThrow(
@@ -174,7 +174,7 @@ describe('MapCLI command', () => {
           instance.execute({
             logger,
             userError,
-            flags: {},
+            flags: { timeout: 123 },
             args: { providerName, profileId: '!_0%L' },
           })
         ).rejects.toThrow(
@@ -194,7 +194,7 @@ describe('MapCLI command', () => {
           instance.execute({
             logger,
             userError,
-            flags: {},
+            flags: { timeout: 123 },
             args: { providerName, profileId: profileName },
           })
         ).rejects.toThrow('File read error');
@@ -213,7 +213,7 @@ describe('MapCLI command', () => {
           instance.execute({
             logger,
             userError,
-            flags: {},
+            flags: { timeout: 123 },
             args: { providerName, profileId: profileName },
           })
         ).rejects.toThrow(`Invalid profile ${profileName}: `);
@@ -233,7 +233,7 @@ describe('MapCLI command', () => {
           instance.execute({
             logger,
             userError,
-            flags: {},
+            flags: { timeout: 123 },
             args: { providerName, profileId: profileName },
           })
         ).rejects.toThrow(
@@ -255,7 +255,7 @@ describe('MapCLI command', () => {
           instance.execute({
             logger,
             userError,
-            flags: {},
+            flags: { timeout: 123 },
             args: { providerName, profileId: profileName },
           })
         ).rejects.toThrow(
@@ -296,7 +296,7 @@ describe('MapCLI command', () => {
       await instance.execute({
         logger,
         userError,
-        flags: {},
+        flags: { timeout: 123 },
         args: { providerName, profileId: profileName },
       });
 
@@ -304,7 +304,7 @@ describe('MapCLI command', () => {
         {
           providerJson,
           profile: source,
-          options: { quiet: undefined },
+          options: { quiet: undefined, timeout: 123 },
         },
         { ux, userError }
       );
@@ -350,7 +350,7 @@ describe('MapCLI command', () => {
       await instance.execute({
         logger,
         userError,
-        flags: {},
+        flags: { timeout: 123 },
         args: { providerName, profileId: profileScope + '.' + profileName },
       });
 
@@ -359,7 +359,7 @@ describe('MapCLI command', () => {
           providerJson,
           profile: source,
 
-          options: { quiet: undefined },
+          options: { quiet: undefined, timeout: 123 },
         },
         { ux, userError }
       );
@@ -425,7 +425,7 @@ describe('MapCLI command', () => {
       await instance.execute({
         logger,
         userError,
-        flags: {},
+        flags: { timeout: 123 },
         args: { providerName, profileId: profileName },
       });
 
@@ -433,7 +433,7 @@ describe('MapCLI command', () => {
         {
           providerJson,
           profile: source,
-          options: { quiet: undefined },
+          options: { quiet: undefined, timeout: 123 },
         },
         { ux, userError }
       );
@@ -497,7 +497,7 @@ describe('MapCLI command', () => {
       await instance.execute({
         logger,
         userError,
-        flags: {},
+        flags: { timeout: 123 },
         args: { providerName, profileId: profileName, language: 'python' },
       });
 
@@ -505,7 +505,7 @@ describe('MapCLI command', () => {
         {
           providerJson,
           profile: source,
-          options: { quiet: undefined },
+          options: { quiet: undefined, timeout: 123 },
         },
         { ux, userError }
       );

--- a/src/commands/map.ts
+++ b/src/commands/map.ts
@@ -75,7 +75,7 @@ export default class Map extends Command {
     timeout: oclifFlags.integer({
       char: 't',
       required: false,
-      description: `Opration timeout in seconds. If not provided, it will be set to ${DEFAULT_POLLING_TIMEOUT_SECONDS} seconds. Usefull for large APIs.`,
+      description: `Operation timeout in seconds. If not provided, it will be set to ${DEFAULT_POLLING_TIMEOUT_SECONDS} seconds. Useful for large API documentations.`,
       default: DEFAULT_POLLING_TIMEOUT_SECONDS,
     }),
   };

--- a/src/commands/map.ts
+++ b/src/commands/map.ts
@@ -1,3 +1,4 @@
+import { flags as oclifFlags } from '@oclif/command';
 import type { ProfileDocumentNode, ProviderJson } from '@superfaceai/ast';
 import { parseDocumentId, parseProfile, Source } from '@superfaceai/parser';
 
@@ -16,6 +17,7 @@ import { fetchSDKToken, SuperfaceClient } from '../common/http';
 import { exists, readFile, readFileQuiet } from '../common/io';
 import type { ILogger } from '../common/log';
 import { OutputStream } from '../common/output-stream';
+import { DEFAULT_POLLING_TIMEOUT_SECONDS } from '../common/polling';
 import { ProfileId } from '../common/profile';
 import { resolveProviderJson } from '../common/provider';
 import { UX } from '../common/ux';
@@ -70,6 +72,12 @@ export default class Map extends Command {
 
   public static flags = {
     ...Command.flags,
+    timeout: oclifFlags.integer({
+      char: 't',
+      required: false,
+      description: `Opration timeout in seconds. If not provided, it will be set to ${DEFAULT_POLLING_TIMEOUT_SECONDS} seconds. Usefull for large APIs.`,
+      default: DEFAULT_POLLING_TIMEOUT_SECONDS,
+    }),
   };
 
   public async run(): Promise<void> {
@@ -126,7 +134,7 @@ export default class Map extends Command {
       {
         providerJson: resolvedProviderJson.providerJson,
         profile: profile.source,
-        options: { quiet: flags.quiet },
+        options: { quiet: flags.quiet, timeout: flags.timeout },
       },
       { userError, ux }
     );

--- a/src/commands/new.test.ts
+++ b/src/commands/new.test.ts
@@ -55,7 +55,7 @@ describe('new CLI command', () => {
         await expect(
           instance.execute({
             userError,
-            flags: {},
+            flags: { timeout: 123 },
             args: { prompt },
           })
         ).rejects.toThrow(
@@ -71,7 +71,7 @@ describe('new CLI command', () => {
         await expect(
           instance.execute({
             userError,
-            flags: {},
+            flags: { timeout: 123 },
             args: { providerName },
           })
         ).rejects.toThrow(
@@ -96,7 +96,7 @@ describe('new CLI command', () => {
 
       await instance.execute({
         userError,
-        flags: {},
+        flags: { timeout: 123 },
         args: { providerName, prompt },
       });
 
@@ -104,7 +104,7 @@ describe('new CLI command', () => {
         {
           providerJson,
           prompt,
-          options: { quiet: undefined },
+          options: { quiet: undefined, timeout: 123 },
         },
         { ux, userError }
       );
@@ -129,7 +129,7 @@ describe('new CLI command', () => {
       await expect(
         instance.execute({
           userError,
-          flags: {},
+          flags: { timeout: 123 },
           args: { providerName, prompt, profileId: 'n0tV4l!d' },
         })
       ).rejects.toThrow(
@@ -148,7 +148,7 @@ describe('new CLI command', () => {
 
       await instance.execute({
         userError,
-        flags: {},
+        flags: { timeout: 123 },
         args: { providerName, prompt, profileId: 'custom-scope/custom-name' },
       });
 
@@ -158,7 +158,7 @@ describe('new CLI command', () => {
           prompt,
           profileName: 'custom-name',
           profileScope: 'custom-scope',
-          options: { quiet: undefined },
+          options: { quiet: undefined, timeout: 123 },
         },
         { ux, userError }
       );
@@ -180,7 +180,7 @@ describe('new CLI command', () => {
 
       await instance.execute({
         userError,
-        flags: {},
+        flags: { timeout: 123 },
         args: { providerName, prompt },
       });
 
@@ -188,7 +188,7 @@ describe('new CLI command', () => {
         {
           providerJson,
           prompt,
-          options: { quiet: undefined },
+          options: { quiet: undefined, timeout: 123 },
         },
         { ux, userError }
       );
@@ -210,7 +210,7 @@ describe('new CLI command', () => {
 
       await instance.execute({
         userError,
-        flags: {},
+        flags: { timeout: 123 },
         args: { providerName, prompt },
       });
 
@@ -218,7 +218,7 @@ describe('new CLI command', () => {
         {
           providerJson,
           prompt,
-          options: { quiet: undefined },
+          options: { quiet: undefined, timeout: 123 },
         },
         { ux, userError }
       );

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -53,7 +53,7 @@ export default class New extends Command {
     timeout: oclifFlags.integer({
       char: 't',
       required: false,
-      description: `Opration timeout in seconds. If not provided, it will be set to ${DEFAULT_POLLING_TIMEOUT_SECONDS} seconds. Usefull for large APIs.`,
+      description: `Operation timeout in seconds. If not provided, it will be set to ${DEFAULT_POLLING_TIMEOUT_SECONDS} seconds. Useful for large API documentations.`,
       default: DEFAULT_POLLING_TIMEOUT_SECONDS,
     }),
   };

--- a/src/commands/new.ts
+++ b/src/commands/new.ts
@@ -1,3 +1,4 @@
+import { flags as oclifFlags } from '@oclif/command';
 import { basename } from 'path';
 
 import type { Flags } from '../common/command.abstract';
@@ -8,6 +9,7 @@ import { formatPath } from '../common/format';
 import { SuperfaceClient } from '../common/http';
 import { exists } from '../common/io';
 import { OutputStream } from '../common/output-stream';
+import { DEFAULT_POLLING_TIMEOUT_SECONDS } from '../common/polling';
 import { ProfileId } from '../common/profile';
 import { resolveProviderJson } from '../common/provider';
 import { UX } from '../common/ux';
@@ -48,6 +50,12 @@ export default class New extends Command {
 
   public static flags = {
     ...Command.flags,
+    timeout: oclifFlags.integer({
+      char: 't',
+      required: false,
+      description: `Opration timeout in seconds. If not provided, it will be set to ${DEFAULT_POLLING_TIMEOUT_SECONDS} seconds. Usefull for large APIs.`,
+      default: DEFAULT_POLLING_TIMEOUT_SECONDS,
+    }),
   };
 
   public async run(): Promise<void> {
@@ -101,7 +109,7 @@ export default class New extends Command {
         prompt: prompt,
         profileName: customProfileId?.name,
         profileScope: customProfileId?.scope,
-        options: { quiet: flags.quiet },
+        options: { quiet: flags.quiet, timeout: flags.timeout },
       },
       { userError, ux }
     );

--- a/src/commands/prepare.test.ts
+++ b/src/commands/prepare.test.ts
@@ -51,7 +51,7 @@ describe('prepare CLI command', () => {
         instance.execute({
           logger,
           userError,
-          flags: {},
+          flags: { timeout: 123 },
           args: { urlOrPath: 'path/to/file.yaml', name: 'd.!"-=' },
         })
       ).rejects.toThrow(
@@ -61,7 +61,12 @@ describe('prepare CLI command', () => {
 
     it('throws when provided name is not valid provider name', async () => {
       await expect(
-        instance.execute({ logger, userError, flags: {}, args: {} })
+        instance.execute({
+          logger,
+          userError,
+          flags: { timeout: 123 },
+          args: {},
+        })
       ).rejects.toThrow(
         'Missing first argument, please provide URL or filepath of API documentation.'
       );
@@ -72,7 +77,7 @@ describe('prepare CLI command', () => {
         instance.execute({
           logger,
           userError,
-          flags: {},
+          flags: { timeout: 123 },
           args: { urlOrPath: 'path/to/file.py' },
         })
       ).rejects.toThrow(
@@ -86,7 +91,7 @@ describe('prepare CLI command', () => {
         instance.execute({
           logger,
           userError,
-          flags: {},
+          flags: { timeout: 123 },
           args: { urlOrPath: 'path/to/file.yaml' },
         })
       ).rejects.toThrow('File path/to/file.yaml does not exist.');
@@ -99,7 +104,7 @@ describe('prepare CLI command', () => {
         instance.execute({
           logger,
           userError,
-          flags: {},
+          flags: { timeout: 123 },
           args: { urlOrPath: 'path/to/file.yaml' },
         })
       ).rejects.toThrow('Could not read file path/to/file.yaml.');
@@ -115,7 +120,7 @@ describe('prepare CLI command', () => {
         instance.execute({
           logger,
           userError,
-          flags: {},
+          flags: { timeout: 123 },
           args: { urlOrPath: 'path/to/file.yaml' },
         })
       ).rejects.toThrow(`Provider ${providerJson.name} already exists.`);
@@ -135,7 +140,7 @@ describe('prepare CLI command', () => {
         instance.execute({
           logger,
           userError,
-          flags: {},
+          flags: { timeout: 123 },
           args: { urlOrPath: 'path/to/FILE.docs.2!87.yaml' },
         })
       ).rejects.toThrow(
@@ -152,7 +157,7 @@ describe('prepare CLI command', () => {
       await instance.execute({
         logger,
         userError,
-        flags: {},
+        flags: { timeout: 123 },
         args: { urlOrPath: url },
       });
 
@@ -160,7 +165,7 @@ describe('prepare CLI command', () => {
         {
           urlOrSource: url,
           name: undefined,
-          options: { quiet: undefined },
+          options: { quiet: undefined, timeout: 123 },
         },
         { ux, userError }
       );
@@ -181,7 +186,7 @@ describe('prepare CLI command', () => {
       await instance.execute({
         logger,
         userError,
-        flags: {},
+        flags: { timeout: 123 },
         args: { urlOrPath: url, name },
       });
 
@@ -189,7 +194,7 @@ describe('prepare CLI command', () => {
         {
           urlOrSource: url,
           name,
-          options: { quiet: undefined },
+          options: { quiet: undefined, timeout: 123 },
         },
         { ux, userError }
       );
@@ -213,7 +218,7 @@ describe('prepare CLI command', () => {
       await instance.execute({
         logger,
         userError,
-        flags: {},
+        flags: { timeout: 123 },
         args: { urlOrPath: 'path/to/FILE!docs.yaml' },
       });
 
@@ -221,7 +226,7 @@ describe('prepare CLI command', () => {
         {
           urlOrSource: fileContent,
           name: 'file-docs',
-          options: { quiet: undefined },
+          options: { quiet: undefined, timeout: 123 },
         },
         { ux, userError }
       );
@@ -246,7 +251,7 @@ describe('prepare CLI command', () => {
       await instance.execute({
         logger,
         userError,
-        flags: {},
+        flags: { timeout: 123 },
         args: { urlOrPath: 'path/to/name.yaml', name },
       });
 
@@ -254,7 +259,7 @@ describe('prepare CLI command', () => {
         {
           urlOrSource: fileContent,
           name,
-          options: { quiet: undefined },
+          options: { quiet: undefined, timeout: 123 },
         },
         { userError, ux }
       );

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -75,7 +75,7 @@ This command prepares a Provider JSON metadata definition that can be used to ge
     timeout: oclifFlags.integer({
       char: 't',
       required: false,
-      description: `Opration timeout in seconds. If not provided, it will be set to ${DEFAULT_POLLING_TIMEOUT_SECONDS} seconds. Usefull for large APIs.`,
+      description: `Operation timeout in seconds. If not provided, it will be set to ${DEFAULT_POLLING_TIMEOUT_SECONDS} seconds. Useful for large API documentations.`,
       default: DEFAULT_POLLING_TIMEOUT_SECONDS,
     }),
   };

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -1,3 +1,4 @@
+import { flags as oclifFlags } from '@oclif/command';
 import type { ProviderJson } from '@superfaceai/ast';
 import { isValidProviderName } from '@superfaceai/ast';
 import { basename, extname } from 'path';
@@ -13,6 +14,7 @@ import { formatPath } from '../common/format';
 import { exists, mkdir, readFile } from '../common/io';
 import type { ILogger } from '../common/log';
 import { OutputStream } from '../common/output-stream';
+import { DEFAULT_POLLING_TIMEOUT_SECONDS } from '../common/polling';
 import { UX } from '../common/ux';
 import { prepareProviderJson } from '../logic/prepare';
 
@@ -70,6 +72,12 @@ This command prepares a Provider JSON metadata definition that can be used to ge
 
   public static flags = {
     ...Command.flags,
+    timeout: oclifFlags.integer({
+      char: 't',
+      required: false,
+      description: `Opration timeout in seconds. If not provided, it will be set to ${DEFAULT_POLLING_TIMEOUT_SECONDS} seconds. Usefull for large APIs.`,
+      default: DEFAULT_POLLING_TIMEOUT_SECONDS,
+    }),
   };
 
   public async run(): Promise<void> {
@@ -115,7 +123,7 @@ This command prepares a Provider JSON metadata definition that can be used to ge
       {
         urlOrSource: resolved.source,
         name: resolved.name,
-        options: { quiet: flags.quiet },
+        options: { quiet: flags.quiet, timeout: flags.timeout },
       },
       { userError, ux }
     );

--- a/src/common/polling.test.ts
+++ b/src/common/polling.test.ts
@@ -51,7 +51,10 @@ describe('polling', () => {
       pollUrl(
         {
           url: jobUrl,
-          options: { quiet: false },
+          options: {
+            quiet: false,
+            pollingTimeoutSeconds: 300,
+          },
         },
         { client, ux, userError }
       )
@@ -106,7 +109,10 @@ describe('polling', () => {
       pollUrl(
         {
           url: jobUrl,
-          options: { quiet: false },
+          options: {
+            quiet: false,
+            pollingTimeoutSeconds: 300,
+          },
         },
         { client, ux, userError }
       )
@@ -154,7 +160,10 @@ describe('polling', () => {
       pollUrl(
         {
           url: jobUrl,
-          options: { quiet: false },
+          options: {
+            quiet: false,
+            pollingTimeoutSeconds: 300,
+          },
         },
         { client, ux, userError }
       )
@@ -205,7 +214,10 @@ describe('polling', () => {
       pollUrl(
         {
           url: jobUrl,
-          options: { quiet: false },
+          options: {
+            quiet: false,
+            pollingTimeoutSeconds: 300,
+          },
         },
         { client, ux, userError }
       )
@@ -265,6 +277,7 @@ describe('polling', () => {
           url: jobUrl,
           options: {
             quiet: false,
+            pollingTimeoutSeconds: 300,
           },
         },
         { client, ux, userError }
@@ -293,6 +306,7 @@ describe('polling', () => {
           url: jobUrl,
           options: {
             quiet: false,
+            pollingTimeoutSeconds: 300,
           },
         },
         { client, ux, userError }
@@ -326,7 +340,10 @@ describe('polling', () => {
         pollUrl(
           {
             url: jobUrl,
-            options: { quiet: false },
+            options: {
+              quiet: false,
+              pollingTimeoutSeconds: 300,
+            },
           },
           { client, ux, userError }
         )
@@ -346,7 +363,10 @@ describe('polling', () => {
         pollUrl(
           {
             url: jobUrl,
-            options: { quiet: false },
+            options: {
+              quiet: false,
+              pollingTimeoutSeconds: 300,
+            },
           },
           { client, ux, userError }
         )
@@ -366,7 +386,10 @@ describe('polling', () => {
         pollUrl(
           {
             url: jobUrl,
-            options: { quiet: false },
+            options: {
+              quiet: false,
+              pollingTimeoutSeconds: 300,
+            },
           },
           { client, ux, userError }
         )

--- a/src/common/polling.ts
+++ b/src/common/polling.ts
@@ -4,7 +4,7 @@ import type { UserError } from './error';
 import { stringifyError } from './error';
 import type { UX } from './ux';
 
-export const DEFAULT_POLLING_TIMEOUT_SECONDS = 600;
+export const DEFAULT_POLLING_TIMEOUT_SECONDS = 300;
 export const DEFAULT_POLLING_INTERVAL_SECONDS = 2;
 export const DEFAULT_NUMBER_OF_RETRIES = 3;
 
@@ -89,8 +89,8 @@ export async function pollUrl(
     options,
   }: {
     url: string;
-    options?: {
-      pollingTimeoutSeconds?: number;
+    options: {
+      pollingTimeoutSeconds: number;
       pollingIntervalSeconds?: number;
       quiet?: boolean;
     };
@@ -106,8 +106,7 @@ export async function pollUrl(
   }
 ): Promise<string> {
   const startPollingTimeStamp = new Date();
-  const timeoutMilliseconds =
-    (options?.pollingTimeoutSeconds ?? DEFAULT_POLLING_TIMEOUT_SECONDS) * 1000;
+  const timeoutMilliseconds = options.pollingTimeoutSeconds * 1000;
   const pollingIntervalMilliseconds =
     (options?.pollingIntervalSeconds ?? DEFAULT_POLLING_INTERVAL_SECONDS) *
     1000;

--- a/src/logic/map.test.ts
+++ b/src/logic/map.test.ts
@@ -69,6 +69,7 @@ describe('mapProviderToProfile', () => {
         {
           providerJson,
           profile: profileSource,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -83,7 +84,10 @@ describe('mapProviderToProfile', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://superface.ai/job/123', {
@@ -104,6 +108,7 @@ describe('mapProviderToProfile', () => {
         {
           providerJson,
           profile: profileSource,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -131,6 +136,7 @@ describe('mapProviderToProfile', () => {
         {
           providerJson,
           profile: profileSource,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -165,6 +171,7 @@ describe('mapProviderToProfile', () => {
         {
           providerJson,
           profile: profileSource,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -201,6 +208,7 @@ describe('mapProviderToProfile', () => {
         {
           providerJson,
           profile: profileSource,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -215,7 +223,10 @@ describe('mapProviderToProfile', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
   });
@@ -239,6 +250,7 @@ describe('mapProviderToProfile', () => {
         {
           providerJson,
           profile: profileSource,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -253,7 +265,10 @@ describe('mapProviderToProfile', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://superface.ai/job/123', {
@@ -284,6 +299,7 @@ describe('mapProviderToProfile', () => {
         {
           providerJson,
           profile: profileSource,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -298,7 +314,10 @@ describe('mapProviderToProfile', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://superface.ai/job/123', {

--- a/src/logic/map.ts
+++ b/src/logic/map.ts
@@ -33,8 +33,9 @@ export async function mapProviderToProfile(
   }: {
     providerJson: ProviderJson;
     profile: string;
-    options?: {
+    options: {
       quiet?: boolean;
+      timeout: number;
     };
   },
   { ux, userError }: { ux: UX; userError: UserError }
@@ -48,7 +49,13 @@ export async function mapProviderToProfile(
   );
 
   const resultUrl = await pollUrl(
-    { url: jobUrl, options: { quiet: options?.quiet } },
+    {
+      url: jobUrl,
+      options: {
+        quiet: options.quiet,
+        pollingTimeoutSeconds: options.timeout,
+      },
+    },
     { client, ux, userError }
   );
 

--- a/src/logic/new.test.ts
+++ b/src/logic/new.test.ts
@@ -73,6 +73,7 @@ describe('newProfile', () => {
         {
           providerJson: mockProvider,
           prompt,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -88,7 +89,10 @@ describe('newProfile', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://superface.ai/job/123', {
@@ -123,6 +127,7 @@ describe('newProfile', () => {
         {
           providerJson: mockProvider,
           prompt,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -138,7 +143,10 @@ describe('newProfile', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://superface.ai/job/123', {
@@ -175,6 +183,7 @@ describe('newProfile', () => {
           prompt,
           profileName: 'custom-name',
           profileScope: 'custom-scope',
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -195,7 +204,10 @@ describe('newProfile', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://superface.ai/job/123', {
@@ -230,6 +242,7 @@ describe('newProfile', () => {
         {
           providerJson: mockProvider,
           prompt,
+          options: { timeout: 123 },
         },
         { ux, userError }
       )
@@ -244,7 +257,10 @@ describe('newProfile', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://superface.ai/job/123', {
@@ -265,6 +281,7 @@ describe('newProfile', () => {
         {
           providerJson: mockProvider,
           prompt,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -289,6 +306,7 @@ describe('newProfile', () => {
         {
           providerJson: mockProvider,
           prompt,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -320,6 +338,7 @@ describe('newProfile', () => {
         {
           providerJson: mockProvider,
           prompt,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -353,6 +372,7 @@ describe('newProfile', () => {
         {
           providerJson: mockProvider,
           prompt,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -364,7 +384,10 @@ describe('newProfile', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
   });
@@ -388,6 +411,7 @@ describe('newProfile', () => {
         {
           providerJson: mockProvider,
           prompt,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -399,7 +423,10 @@ describe('newProfile', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://superface.ai/job/123', {
@@ -430,6 +457,7 @@ describe('newProfile', () => {
         {
           providerJson: mockProvider,
           prompt,
+          options: { timeout: 123 },
         },
         { userError, ux }
       )
@@ -441,7 +469,10 @@ describe('newProfile', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://superface.ai/job/123', {

--- a/src/logic/new.ts
+++ b/src/logic/new.ts
@@ -71,7 +71,7 @@ export async function newProfile(
     prompt: string;
     profileName?: string;
     profileScope?: string;
-    options?: { quiet?: boolean };
+    options: { quiet?: boolean; timeout: number };
   },
   { userError, ux }: { userError: UserError; ux: UX }
 ): Promise<{ source: string; scope?: string; name: string }> {
@@ -83,7 +83,13 @@ export async function newProfile(
   );
 
   const resultUrl = await pollUrl(
-    { url: jobUrl, options: { quiet: options?.quiet } },
+    {
+      url: jobUrl,
+      options: {
+        quiet: options.quiet,
+        pollingTimeoutSeconds: options.timeout,
+      },
+    },
     { client, userError, ux }
   );
 

--- a/src/logic/prepare.test.ts
+++ b/src/logic/prepare.test.ts
@@ -52,6 +52,7 @@ describe('prepareProviderJson', () => {
         {
           urlOrSource: 'https://superface.ai/path/to/oas.json',
           name: providerName,
+          options: { timeout: 123 },
         },
         { ux, userError }
       )
@@ -63,7 +64,10 @@ describe('prepareProviderJson', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://superface.ai/job/123', {
@@ -84,6 +88,7 @@ describe('prepareProviderJson', () => {
         {
           urlOrSource: 'https://superface.ai/path/to/oas.json',
           name: providerName,
+          options: { timeout: 123 },
         },
         { ux, userError }
       )
@@ -108,6 +113,7 @@ describe('prepareProviderJson', () => {
         {
           urlOrSource: 'https://superface.ai/path/to/oas.json',
           name: providerName,
+          options: { timeout: 123 },
         },
         { ux, userError }
       )
@@ -139,6 +145,7 @@ describe('prepareProviderJson', () => {
         {
           urlOrSource: 'https://superface.ai/path/to/oas.json',
           name: providerName,
+          options: { timeout: 123 },
         },
         { ux, userError }
       )
@@ -172,6 +179,7 @@ describe('prepareProviderJson', () => {
         {
           urlOrSource: 'https://superface.ai/path/to/oas.json',
           name: providerName,
+          options: { timeout: 123 },
         },
         { ux, userError }
       )
@@ -183,7 +191,10 @@ describe('prepareProviderJson', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
   });
@@ -207,6 +218,7 @@ describe('prepareProviderJson', () => {
         {
           urlOrSource: 'https://superface.ai/path/to/oas.json',
           name: providerName,
+          options: { timeout: 123 },
         },
         { ux, userError }
       )
@@ -218,7 +230,10 @@ describe('prepareProviderJson', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://superface.ai/job/123', {
@@ -249,6 +264,7 @@ describe('prepareProviderJson', () => {
         {
           urlOrSource: 'https://superface.ai/path/to/oas.json',
           name: providerName,
+          options: { timeout: 123 },
         },
         { ux, userError }
       )
@@ -260,7 +276,10 @@ describe('prepareProviderJson', () => {
       method: 'POST',
     });
     expect(pollUrl).toHaveBeenCalledWith(
-      { options: { quiet: undefined }, url: 'https://superface.ai/job/123' },
+      {
+        options: { quiet: undefined, pollingTimeoutSeconds: 123 },
+        url: 'https://superface.ai/job/123',
+      },
       { client: expect.any(ServiceClient), ux, userError }
     );
     expect(fetch).toHaveBeenNthCalledWith(2, 'https://superface.ai/job/123', {

--- a/src/logic/prepare.ts
+++ b/src/logic/prepare.ts
@@ -51,8 +51,9 @@ export async function prepareProviderJson(
   }: {
     urlOrSource: string;
     name: string | undefined;
-    options?: {
+    options: {
       quiet?: boolean;
+      timeout: number;
     };
   },
   { userError, ux }: { userError: UserError; ux: UX }
@@ -65,7 +66,13 @@ export async function prepareProviderJson(
   );
 
   const resultUrl = await pollUrl(
-    { url: jobUrl, options: { quiet: options?.quiet } },
+    {
+      url: jobUrl,
+      options: {
+        quiet: options.quiet,
+        pollingTimeoutSeconds: options.timeout,
+      },
+    },
     { client, ux, userError }
   );
 


### PR DESCRIPTION
<!--- Tip: You don't have to remove these comments -->

## Description
This PR adds timeout flag to set up timeout for polling the job. This flag is added to operations that use polling.
Setting timeout enables to work with larger/more complex documentations

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
<!--- If your changes are only to the internals then make sure any function has its attached documentation updated or added (e.g. descriptive name, doc comment, etc.). If your changes are to user-facing APIs or concepts then make sure README.md is updated accordingly (e.g. command help output). -->
- [ ] I have updated the documentation accordingly. For updating Oclif commands documentation use [oclif-dev](https://github.com/oclif/dev-cli#oclif-dev-readme).
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I haven't repeated the code. (DRY)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
